### PR TITLE
Fixes #6 - Update go-infoblox version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.6.2
+  - 1.7.5
 install:
   - echo noop
 script:

--- a/infoblox/resource_infoblox_record.go
+++ b/infoblox/resource_infoblox_record.go
@@ -97,7 +97,7 @@ func resourceInfobloxRecordRead(d *schema.ResourceData, meta interface{}) error 
 
 	switch strings.ToUpper(d.Get("type").(string)) {
 	case "A":
-		rec, err := client.GetRecordA(d.Id())
+		rec, err := client.GetRecordA(d.Id(), nil)
 		if err != nil {
 			return fmt.Errorf("Couldn't find Infoblox A record: %s", err)
 		}
@@ -109,7 +109,7 @@ func resourceInfobloxRecordRead(d *schema.ResourceData, meta interface{}) error 
 		d.Set("ttl", rec.Ttl)
 
 	case "AAAA":
-		rec, err := client.GetRecordAAAA(d.Id())
+		rec, err := client.GetRecordAAAA(d.Id(), nil)
 		if err != nil {
 			return fmt.Errorf("Couldn't find Infoblox AAAA record: %s", err)
 		}
@@ -121,11 +121,11 @@ func resourceInfobloxRecordRead(d *schema.ResourceData, meta interface{}) error 
 		d.Set("ttl", rec.Ttl)
 
 	case "CNAME":
-		rec, err := client.GetRecordCname(d.Id())
+		rec, err := client.GetRecordCname(d.Id(), nil)
 		if err != nil {
 			return fmt.Errorf("Couldn't find Infoblox CNAME record: %s", err)
 		}
-		d.Set("value", rec.Canoncial)
+		d.Set("value", rec.Canonical)
 		d.Set("type", "CNAME")
 		fqdn := strings.Split(rec.Name, ".")
 		d.Set("name", fqdn[0])
@@ -144,11 +144,11 @@ func resourceInfobloxRecordUpdate(d *schema.ResourceData, meta interface{}) erro
 	var err, updateErr error
 	switch strings.ToUpper(d.Get("type").(string)) {
 	case "A":
-		_, err = client.GetRecordA(d.Id())
+		_, err = client.GetRecordA(d.Id(), nil)
 	case "AAAA":
-		_, err = client.GetRecordAAAA(d.Id())
+		_, err = client.GetRecordAAAA(d.Id(), nil)
 	case "CNAME":
-		_, err = client.GetRecordCname(d.Id())
+		_, err = client.GetRecordCname(d.Id(), nil)
 	default:
 		return fmt.Errorf("resourceInfobloxRecordUpdate: unknown type")
 	}
@@ -169,17 +169,17 @@ func resourceInfobloxRecordUpdate(d *schema.ResourceData, meta interface{}) erro
 		opts := &infoblox.Options{
 			ReturnFields: []string{"ttl", "ipv4addr", "name"},
 		}
-		recID, updateErr = client.RecordAObject(d.Id()).Update(record, opts)
+		recID, updateErr = client.RecordAObject(d.Id()).Update(record, opts, nil)
 	case "AAAA":
 		opts := &infoblox.Options{
 			ReturnFields: []string{"ttl", "ipv6addr", "name"},
 		}
-		recID, updateErr = client.RecordAAAAObject(d.Id()).Update(record, opts)
+		recID, updateErr = client.RecordAAAAObject(d.Id()).Update(record, opts, nil)
 	case "CNAME":
 		opts := &infoblox.Options{
 			ReturnFields: []string{"ttl", "canonical", "name"},
 		}
-		recID, updateErr = client.RecordCnameObject(d.Id()).Update(record, opts)
+		recID, updateErr = client.RecordCnameObject(d.Id()).Update(record, opts, nil)
 	default:
 		return fmt.Errorf("resourceInfobloxRecordUpdate: unknown type")
 	}
@@ -199,7 +199,7 @@ func resourceInfobloxRecordDelete(d *schema.ResourceData, meta interface{}) erro
 	log.Printf("[INFO] Deleting Infoblox Record: %s, %s", d.Get("name").(string), d.Id())
 	switch strings.ToUpper(d.Get("type").(string)) {
 	case "A":
-		_, err := client.GetRecordA(d.Id())
+		_, err := client.GetRecordA(d.Id(), nil)
 		if err != nil {
 			return fmt.Errorf("Couldn't find Infoblox A record: %s", err)
 		}
@@ -209,7 +209,7 @@ func resourceInfobloxRecordDelete(d *schema.ResourceData, meta interface{}) erro
 			return fmt.Errorf("Error deleting Infoblox A Record: %s", err)
 		}
 	case "AAAA":
-		_, err := client.GetRecordAAAA(d.Id())
+		_, err := client.GetRecordAAAA(d.Id(), nil)
 		if err != nil {
 			return fmt.Errorf("Couldn't find Infoblox AAAA record: %s", err)
 		}
@@ -219,7 +219,7 @@ func resourceInfobloxRecordDelete(d *schema.ResourceData, meta interface{}) erro
 			return fmt.Errorf("Error deleting Infoblox AAAA Record: %s", err)
 		}
 	case "CNAME":
-		_, err := client.GetRecordCname(d.Id())
+		_, err := client.GetRecordCname(d.Id(), nil)
 		if err != nil {
 			return fmt.Errorf("Couldn't find Infoblox CNAME record: %s", err)
 		}

--- a/infoblox/resource_infoblox_record_test.go
+++ b/infoblox/resource_infoblox_record_test.go
@@ -154,11 +154,11 @@ func testAccCheckInfobloxRecordDestroy(s *terraform.State) error {
 
 		switch strings.ToUpper(rs.Primary.Attributes["type"]) {
 		case "A":
-			_, err = client.GetRecordA(rs.Primary.ID)
+			_, err = client.GetRecordA(rs.Primary.ID, nil)
 		case "AAAA":
-			_, err = client.GetRecordAAAA(rs.Primary.ID)
+			_, err = client.GetRecordAAAA(rs.Primary.ID, nil)
 		case "CNAME":
-			_, err = client.GetRecordCname(rs.Primary.ID)
+			_, err = client.GetRecordCname(rs.Primary.ID, nil)
 		default:
 			return fmt.Errorf("testAccCheckInfobloxRecordDestroy: unknown type")
 		}
@@ -184,7 +184,7 @@ func testAccCheckInfobloxRecordAExists(n string, record *infoblox.RecordAObject)
 		}
 
 		client := testAccProvider.Meta().(*infoblox.Client)
-		foundRecord, err := client.GetRecordA(rs.Primary.ID)
+		foundRecord, err := client.GetRecordA(rs.Primary.ID, nil)
 
 		if err != nil {
 			return err
@@ -213,7 +213,7 @@ func testAccCheckInfobloxRecordAAAAExists(n string, record *infoblox.RecordAAAAO
 		}
 
 		client := testAccProvider.Meta().(*infoblox.Client)
-		foundRecord, err := client.GetRecordAAAA(rs.Primary.ID)
+		foundRecord, err := client.GetRecordAAAA(rs.Primary.ID, nil)
 
 		if err != nil {
 			return err
@@ -242,7 +242,7 @@ func testAccCheckInfobloxRecordCnameExists(n string, record *infoblox.RecordCnam
 		}
 
 		client := testAccProvider.Meta().(*infoblox.Client)
-		foundRecord, err := client.GetRecordCname(rs.Primary.ID)
+		foundRecord, err := client.GetRecordCname(rs.Primary.ID, nil)
 
 		if err != nil {
 			return err

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform/plugin"
+
 	"github.com/prudhvitella/terraform-provider-infoblox/infoblox"
 )
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -147,13 +147,14 @@
 			"revisionTime": "2015-11-05T21:09:06Z"
 		},
 		{
-			"checksumSHA1": "rg4enUG5MIarl/i3n0wzKQu2jIU=",
+			"checksumSHA1": "93KS1lqzjodFXlunKWN3byjpYkA=",
 			"path": "github.com/fanatic/go-infoblox",
-			"revision": "d2a0c53da1cf587c82eac7e1d7ae3c35434c1301",
-			"revisionTime": "2015-12-01T22:57:18Z"
+			"revision": "bf85b43199f3bac34c9cff287e742ec680983210",
+			"revisionTime": "2017-02-15T21:41:05Z"
 		},
 		{
-      "comment": "v1.18.0",
+			"checksumSHA1": "ce2QegjKgslVfAicMRgHSjeygiI=",
+			"comment": "v1.18.0",
 			"path": "github.com/go-ini/ini",
 			"revision": "cf53f9204df4fbdd7ec4164b57fa6184ba168292"
 		},


### PR DESCRIPTION
https://github.com/fanatic/go-infoblox/pull/26 was merged earlier today and fixes https://github.com/prudhvitella/terraform-provider-infoblox/issues/6.

This commit updates the terraform provider to use the latest version of go-infoblox (which introduced some API changes). Instead of `panic`king with misconfigured host urls, go-infoblox now returns a readable error.