### PR TITLE
Handle incorrect network CIDRs more gracefully

### DIFF
--- a/infoblox/resource_infoblox_ip.go
+++ b/infoblox/resource_infoblox_ip.go
@@ -102,6 +102,10 @@ func resourceInfobloxIPCreate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
+	if len(out) == 0 {
+		return fmt.Errorf("Empty response from client.Network().find. Is %s a valid network?", ntwork)
+	}
+
 	printList(out, nil)
 
 	log.Print("[TRACE] invoking client.NetworkObject().NextAvailableIP")


### PR DESCRIPTION
Currently, if you attempt to create an infoblox_ip resource using a CIDR that is not a managed network in Infoblox, terraform will crash with an unexpected EOF error. 

This is because of the call to `client.Network().Find()(q, nil)`, which returns an empty array instead of an error.

Later the line `ou, err := client.NetworkObject(out[0]["_ref"].(string)).NextAvailableIP(1, nil)` tries to access a non-existent element in the array.

This commit checks the length of `out` and returns an error if it is zero. An example terraform file and crash log are below.

```infoblox.tf
provider "infoblox" {
  # Credentials set in environment vars
  usecookies = "false"
}

resource "infoblox_ip" "foo" {
  cidr = "1.2.3.4/24"
}
```

```crash.log
$ cat crash.log
2017/03/08 15:50:48 [INFO] Terraform version: 0.8.8
2017/03/08 15:50:48 [INFO] CLI args: []string{"/usr/local/Cellar/terraform/0.8.8/bin/terraform", "apply"}
2017/03/08 15:50:48 [DEBUG] Detected home directory from env var: /Users/jack
2017/03/08 15:50:48 [DEBUG] Detected home directory from env var: /Users/jack
2017/03/08 15:50:48 [DEBUG] Attempting to open CLI config file: /Users/jack/.terraformrc
2017/03/08 15:50:48 [DEBUG] Detected home directory from env var: /Users/jack
2017/03/08 15:50:48 [TRACE] Preserving existing state lineage "54f8b580-f479-43e8-89bb-037d786b69e9"
2017/03/08 15:50:48 [TRACE] Preserving existing state lineage "54f8b580-f479-43e8-89bb-037d786b69e9"
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.ConfigTransformerOld:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.OrphanTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.AddOutputOrphanTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.MissingProviderTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.ProviderTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.DisableProviderTransformerOld:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.MissingProvisionerTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.ProvisionerTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.VertexTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.FlattenTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.ProxyTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.TargetsTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.OrphanOutputTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.PruneProviderTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.DestroyTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  infoblox_ip.foo (destroy) - *terraform.graphNodeResourceDestroy
  provider.infoblox - *terraform.GraphNodeConfigProvider
infoblox_ip.foo (destroy) - *terraform.graphNodeResourceDestroy
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.CreateBeforeDestroyTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  infoblox_ip.foo (destroy) - *terraform.graphNodeResourceDestroy
  provider.infoblox - *terraform.GraphNodeConfigProvider
infoblox_ip.foo (destroy) - *terraform.graphNodeResourceDestroy
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.PruneDestroyTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [DEBUG] Checking resource noop: infoblox_ip.foo
2017/03/08 15:50:48 [DEBUG] No diff, not a noop
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.PruneNoopTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.CloseProviderTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
provider.infoblox (close) - *terraform.graphNodeCloseProvider
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.CloseProvisionerTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
provider.infoblox (close) - *terraform.graphNodeCloseProvider
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.TransitiveReductionTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
provider.infoblox (close) - *terraform.graphNodeCloseProvider
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.RootTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
provider.infoblox (close) - *terraform.graphNodeCloseProvider
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
root - terraform.graphNodeRoot
  output.next_available_ip - *terraform.GraphNodeConfigOutput
  provider.infoblox (close) - *terraform.graphNodeCloseProvider
2017/03/08 15:50:48 [DEBUG] Starting graph walk: walkInput
2017/03/08 15:50:48 [DEBUG] vertex 'root.provider.infoblox': walking
2017/03/08 15:50:48 [DEBUG] vertex 'root.provider.infoblox': evaluating
2017/03/08 15:50:48 [TRACE] [walkInput] Entering eval tree: provider.infoblox
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalSequence
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalInitProvider
2017/03/08 15:50:48 [DEBUG] plugin: starting plugin: /usr/local/bin/terraform-provider-infoblox []string{"/usr/local/bin/terraform-provider-infoblox"}
2017/03/08 15:50:48 [DEBUG] plugin: waiting for RPC address for: /usr/local/bin/terraform-provider-infoblox
2017/03/08 15:50:48 [DEBUG] plugin: terraform-provider-infoblox: 2017/03/08 15:50:48 [DEBUG] plugin: plugin address: unix /var/folders/m_/s8m1tp_j2kq8y9l84fh07dch0000gn/T/plugin699860271
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalOpFilter
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalSequence
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalGetProvider
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalInterpolate
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalBuildProviderConfig
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalInputProvider
2017/03/08 15:50:48 [DEBUG] root: eval: terraform.EvalNoop
2017/03/08 15:50:48 [DEBUG] root: eval: terraform.EvalNoop
2017/03/08 15:50:48 [DEBUG] root: eval: terraform.EvalNoop
2017/03/08 15:50:48 [TRACE] [walkInput] Exiting eval tree: provider.infoblox
2017/03/08 15:50:48 [DEBUG] vertex "provider.infoblox (close)", got dep: "provider.infoblox"
2017/03/08 15:50:48 [DEBUG] vertex "infoblox_ip.foo", got dep: "provider.infoblox"
2017/03/08 15:50:48 [DEBUG] vertex 'root.infoblox_ip.foo': walking
2017/03/08 15:50:48 [DEBUG] vertex 'root.infoblox_ip.foo': evaluating
2017/03/08 15:50:48 [TRACE] [walkInput] Entering eval tree: infoblox_ip.foo
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalSequence
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalInterpolate
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalCountCheckComputed
2017/03/08 15:50:48 [DEBUG] root: eval: terraform.EvalNoop
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalCountFixZeroOneBoundary
2017/03/08 15:50:48 [TRACE] [walkInput] Exiting eval tree: infoblox_ip.foo
2017/03/08 15:50:48 [DEBUG] vertex 'root.infoblox_ip.foo': expanding/walking dynamic subgraph
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.ResourceCountTransformerOld:

infoblox_ip.foo - *terraform.graphNodeExpandedResource
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.TargetsTransformer:

infoblox_ip.foo - *terraform.graphNodeExpandedResource
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.RootTransformer:

infoblox_ip.foo - *terraform.graphNodeExpandedResource
2017/03/08 15:50:48 [DEBUG] vertex 'root.infoblox_ip.foo': walking
2017/03/08 15:50:48 [DEBUG] vertex 'root.infoblox_ip.foo': evaluating
2017/03/08 15:50:48 [TRACE] [walkInput] Entering eval tree: infoblox_ip.foo
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalSequence
2017/03/08 15:50:48 [DEBUG] root: eval: terraform.EvalNoop
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalInstanceInfo
2017/03/08 15:50:48 [DEBUG] root: eval: terraform.EvalNoop
2017/03/08 15:50:48 [DEBUG] root: eval: terraform.EvalNoop
2017/03/08 15:50:48 [DEBUG] root: eval: terraform.EvalNoop
2017/03/08 15:50:48 [DEBUG] root: eval: terraform.EvalNoop
2017/03/08 15:50:48 [TRACE] [walkInput] Exiting eval tree: infoblox_ip.foo
2017/03/08 15:50:48 [DEBUG] vertex "output.next_available_ip", got dep: "infoblox_ip.foo"
2017/03/08 15:50:48 [DEBUG] vertex "provider.infoblox (close)", got dep: "infoblox_ip.foo"
2017/03/08 15:50:48 [DEBUG] vertex 'root.output.next_available_ip': walking
2017/03/08 15:50:48 [DEBUG] vertex 'root.output.next_available_ip': evaluating
2017/03/08 15:50:48 [TRACE] [walkInput] Entering eval tree: output.next_available_ip
2017/03/08 15:50:48 [DEBUG] vertex 'root.provider.infoblox (close)': walking
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalOpFilter
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalSequence
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalWriteOutput
2017/03/08 15:50:48 [DEBUG] vertex 'root.provider.infoblox (close)': evaluating
2017/03/08 15:50:48 [TRACE] [walkInput] Entering eval tree: provider.infoblox (close)
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalCloseProvider
2017/03/08 15:50:48 [TRACE] [walkInput] Exiting eval tree: provider.infoblox (close)
2017/03/08 15:50:48 [TRACE] [walkInput] Exiting eval tree: output.next_available_ip
2017/03/08 15:50:48 [DEBUG] vertex "root", got dep: "output.next_available_ip"
2017/03/08 15:50:48 [DEBUG] vertex "root", got dep: "provider.infoblox (close)"
2017/03/08 15:50:48 [DEBUG] vertex 'root.root': walking
2017/03/08 15:50:48 [INFO] Validating the context...
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.ConfigTransformerOld:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.OrphanTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.AddOutputOrphanTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.MissingProviderTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.ProviderTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.DisableProviderTransformerOld:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.MissingProvisionerTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.ProvisionerTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.VertexTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.FlattenTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.ProxyTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.TargetsTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.OrphanOutputTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.PruneProviderTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.DestroyTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  infoblox_ip.foo (destroy) - *terraform.graphNodeResourceDestroy
  provider.infoblox - *terraform.GraphNodeConfigProvider
infoblox_ip.foo (destroy) - *terraform.graphNodeResourceDestroy
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.CreateBeforeDestroyTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  infoblox_ip.foo (destroy) - *terraform.graphNodeResourceDestroy
  provider.infoblox - *terraform.GraphNodeConfigProvider
infoblox_ip.foo (destroy) - *terraform.graphNodeResourceDestroy
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.PruneDestroyTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [DEBUG] Checking resource noop: infoblox_ip.foo
2017/03/08 15:50:48 [DEBUG] No diff, not a noop
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.PruneNoopTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.CloseProviderTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
provider.infoblox (close) - *terraform.graphNodeCloseProvider
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.CloseProvisionerTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
provider.infoblox (close) - *terraform.graphNodeCloseProvider
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.TransitiveReductionTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
provider.infoblox (close) - *terraform.graphNodeCloseProvider
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.RootTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
provider.infoblox (close) - *terraform.graphNodeCloseProvider
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
root - terraform.graphNodeRoot
  output.next_available_ip - *terraform.GraphNodeConfigOutput
  provider.infoblox (close) - *terraform.graphNodeCloseProvider
2017/03/08 15:50:48 [DEBUG] Starting graph walk: walkValidate
2017/03/08 15:50:48 [DEBUG] vertex 'root.provider.infoblox': walking
2017/03/08 15:50:48 [DEBUG] vertex 'root.provider.infoblox': evaluating
2017/03/08 15:50:48 [TRACE] [walkValidate] Entering eval tree: provider.infoblox
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalSequence
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalInitProvider
2017/03/08 15:50:48 [DEBUG] root: eval: terraform.EvalNoop
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalOpFilter
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalSequence
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalGetProvider
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalInterpolate
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalBuildProviderConfig
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalValidateProvider
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalSetProviderConfig
2017/03/08 15:50:48 [DEBUG] root: eval: terraform.EvalNoop
2017/03/08 15:50:48 [DEBUG] root: eval: terraform.EvalNoop
2017/03/08 15:50:48 [TRACE] [walkValidate] Exiting eval tree: provider.infoblox
2017/03/08 15:50:48 [DEBUG] vertex "infoblox_ip.foo", got dep: "provider.infoblox"
2017/03/08 15:50:48 [DEBUG] vertex "provider.infoblox (close)", got dep: "provider.infoblox"
2017/03/08 15:50:48 [DEBUG] vertex 'root.infoblox_ip.foo': walking
2017/03/08 15:50:48 [DEBUG] vertex 'root.infoblox_ip.foo': evaluating
2017/03/08 15:50:48 [TRACE] [walkValidate] Entering eval tree: infoblox_ip.foo
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalSequence
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalInterpolate
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalCountCheckComputed
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalOpFilter
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalValidateCount
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalCountFixZeroOneBoundary
2017/03/08 15:50:48 [TRACE] [walkValidate] Exiting eval tree: infoblox_ip.foo
2017/03/08 15:50:48 [DEBUG] vertex 'root.infoblox_ip.foo': expanding/walking dynamic subgraph
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.ResourceCountTransformerOld:

infoblox_ip.foo - *terraform.graphNodeExpandedResource
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.TargetsTransformer:

infoblox_ip.foo - *terraform.graphNodeExpandedResource
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.RootTransformer:

infoblox_ip.foo - *terraform.graphNodeExpandedResource
2017/03/08 15:50:48 [DEBUG] vertex 'root.infoblox_ip.foo': walking
2017/03/08 15:50:48 [DEBUG] vertex 'root.infoblox_ip.foo': evaluating
2017/03/08 15:50:48 [TRACE] [walkValidate] Entering eval tree: infoblox_ip.foo
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalSequence
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalOpFilter
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalSequence
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalGetProvider
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalInterpolate
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalValidateResource
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalInstanceInfo
2017/03/08 15:50:48 [DEBUG] root: eval: terraform.EvalNoop
2017/03/08 15:50:48 [DEBUG] root: eval: terraform.EvalNoop
2017/03/08 15:50:48 [DEBUG] root: eval: terraform.EvalNoop
2017/03/08 15:50:48 [DEBUG] root: eval: terraform.EvalNoop
2017/03/08 15:50:48 [TRACE] [walkValidate] Exiting eval tree: infoblox_ip.foo
2017/03/08 15:50:48 [DEBUG] vertex "output.next_available_ip", got dep: "infoblox_ip.foo"
2017/03/08 15:50:48 [DEBUG] vertex "provider.infoblox (close)", got dep: "infoblox_ip.foo"
2017/03/08 15:50:48 [DEBUG] vertex 'root.provider.infoblox (close)': walking
2017/03/08 15:50:48 [DEBUG] vertex 'root.provider.infoblox (close)': evaluating
2017/03/08 15:50:48 [DEBUG] vertex 'root.output.next_available_ip': walking
2017/03/08 15:50:48 [TRACE] [walkValidate] Entering eval tree: provider.infoblox (close)
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalCloseProvider
2017/03/08 15:50:48 [DEBUG] vertex 'root.output.next_available_ip': evaluating
2017/03/08 15:50:48 [TRACE] [walkValidate] Exiting eval tree: provider.infoblox (close)
2017/03/08 15:50:48 [TRACE] [walkValidate] Entering eval tree: output.next_available_ip
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalOpFilter
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalSequence
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalWriteOutput
2017/03/08 15:50:48 [TRACE] [walkValidate] Exiting eval tree: output.next_available_ip
2017/03/08 15:50:48 [DEBUG] vertex "root", got dep: "output.next_available_ip"
2017/03/08 15:50:48 [DEBUG] vertex "root", got dep: "provider.infoblox (close)"
2017/03/08 15:50:48 [DEBUG] vertex 'root.root': walking
2017/03/08 15:50:48 [INFO] Validation result: 0 warnings, 0 errors
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.ConfigTransformerOld:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.OrphanTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.AddOutputOrphanTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.MissingProviderTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.ProviderTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.DisableProviderTransformerOld:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.MissingProvisionerTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.ProvisionerTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.VertexTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.FlattenTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.ProxyTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.TargetsTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.OrphanOutputTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.PruneProviderTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.DestroyTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  infoblox_ip.foo (destroy) - *terraform.graphNodeResourceDestroy
  provider.infoblox - *terraform.GraphNodeConfigProvider
infoblox_ip.foo (destroy) - *terraform.graphNodeResourceDestroy
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.CreateBeforeDestroyTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  infoblox_ip.foo (destroy) - *terraform.graphNodeResourceDestroy
  provider.infoblox - *terraform.GraphNodeConfigProvider
infoblox_ip.foo (destroy) - *terraform.graphNodeResourceDestroy
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.PruneDestroyTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [DEBUG] Checking resource noop: infoblox_ip.foo
2017/03/08 15:50:48 [DEBUG] No diff, not a noop
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.PruneNoopTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.CloseProviderTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
provider.infoblox (close) - *terraform.graphNodeCloseProvider
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.CloseProvisionerTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
provider.infoblox (close) - *terraform.graphNodeCloseProvider
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.TransitiveReductionTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
provider.infoblox (close) - *terraform.graphNodeCloseProvider
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.RootTransformer:

infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
output.next_available_ip - *terraform.GraphNodeConfigOutput
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
provider.infoblox - *terraform.GraphNodeConfigProvider
provider.infoblox (close) - *terraform.graphNodeCloseProvider
  infoblox_ip.foo - *terraform.GraphNodeConfigResource
  provider.infoblox - *terraform.GraphNodeConfigProvider
root - terraform.graphNodeRoot
  output.next_available_ip - *terraform.GraphNodeConfigOutput
  provider.infoblox (close) - *terraform.graphNodeCloseProvider
2017/03/08 15:50:48 [DEBUG] Starting graph walk: walkRefresh
2017/03/08 15:50:48 [DEBUG] vertex 'root.provider.infoblox': walking
2017/03/08 15:50:48 [DEBUG] vertex 'root.provider.infoblox': evaluating
2017/03/08 15:50:48 [TRACE] [walkRefresh] Entering eval tree: provider.infoblox
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalSequence
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalInitProvider
2017/03/08 15:50:48 [DEBUG] root: eval: terraform.EvalNoop
2017/03/08 15:50:48 [DEBUG] root: eval: terraform.EvalNoop
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalOpFilter
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalSequence
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalGetProvider
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalInterpolate
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalBuildProviderConfig
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalSetProviderConfig
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalOpFilter
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalSequence
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalConfigProvider
2017/03/08 15:50:48 [DEBUG] plugin: terraform-provider-infoblox: 2017/03/08 15:50:48 WARNING: SSL cert verification  disabled
2017/03/08 15:50:48 [DEBUG] plugin: terraform-provider-infoblox: 2017/03/08 15:50:48 [INFO] Infoblox Client configured for user: FabioAPI
2017/03/08 15:50:48 [TRACE] [walkRefresh] Exiting eval tree: provider.infoblox
2017/03/08 15:50:48 [DEBUG] vertex "infoblox_ip.foo", got dep: "provider.infoblox"
2017/03/08 15:50:48 [DEBUG] vertex "provider.infoblox (close)", got dep: "provider.infoblox"
2017/03/08 15:50:48 [DEBUG] vertex 'root.infoblox_ip.foo': walking
2017/03/08 15:50:48 [DEBUG] vertex 'root.infoblox_ip.foo': evaluating
2017/03/08 15:50:48 [TRACE] [walkRefresh] Entering eval tree: infoblox_ip.foo
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalSequence
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalInterpolate
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalCountCheckComputed
2017/03/08 15:50:48 [DEBUG] root: eval: terraform.EvalNoop
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalCountFixZeroOneBoundary
2017/03/08 15:50:48 [TRACE] [walkRefresh] Exiting eval tree: infoblox_ip.foo
2017/03/08 15:50:48 [DEBUG] vertex 'root.infoblox_ip.foo': expanding/walking dynamic subgraph
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.ResourceCountTransformerOld:

infoblox_ip.foo - *terraform.graphNodeExpandedResource
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.TargetsTransformer:

infoblox_ip.foo - *terraform.graphNodeExpandedResource
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.RootTransformer:

infoblox_ip.foo - *terraform.graphNodeExpandedResource
2017/03/08 15:50:48 [DEBUG] vertex 'root.infoblox_ip.foo': walking
2017/03/08 15:50:48 [DEBUG] vertex 'root.infoblox_ip.foo': evaluating
2017/03/08 15:50:48 [TRACE] [walkRefresh] Entering eval tree: infoblox_ip.foo
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalSequence
2017/03/08 15:50:48 [DEBUG] root: eval: terraform.EvalNoop
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalInstanceInfo
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalOpFilter
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalSequence
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalGetProvider
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalReadState
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalRefresh
2017/03/08 15:50:48 [DEBUG] refresh: infoblox_ip.foo: no state, not refreshing
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalWriteState
2017/03/08 15:50:48 [DEBUG] root: eval: terraform.EvalNoop
2017/03/08 15:50:48 [DEBUG] root: eval: terraform.EvalNoop
2017/03/08 15:50:48 [DEBUG] root: eval: terraform.EvalNoop
2017/03/08 15:50:48 [TRACE] [walkRefresh] Exiting eval tree: infoblox_ip.foo
2017/03/08 15:50:48 [DEBUG] vertex "output.next_available_ip", got dep: "infoblox_ip.foo"
2017/03/08 15:50:48 [DEBUG] vertex "provider.infoblox (close)", got dep: "infoblox_ip.foo"
2017/03/08 15:50:48 [DEBUG] vertex 'root.output.next_available_ip': walking
2017/03/08 15:50:48 [DEBUG] vertex 'root.provider.infoblox (close)': walking
2017/03/08 15:50:48 [DEBUG] vertex 'root.output.next_available_ip': evaluating
2017/03/08 15:50:48 [DEBUG] vertex 'root.provider.infoblox (close)': evaluating
2017/03/08 15:50:48 [TRACE] [walkRefresh] Entering eval tree: output.next_available_ip
2017/03/08 15:50:48 [TRACE] [walkRefresh] Entering eval tree: provider.infoblox (close)
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalCloseProvider
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalOpFilter
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalSequence
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalWriteOutput
2017/03/08 15:50:48 [TRACE] [walkRefresh] Exiting eval tree: provider.infoblox (close)
2017/03/08 15:50:48 [TRACE] [walkRefresh] Exiting eval tree: output.next_available_ip
2017/03/08 15:50:48 [DEBUG] vertex "root", got dep: "output.next_available_ip"
2017/03/08 15:50:48 [DEBUG] vertex "root", got dep: "provider.infoblox (close)"
2017/03/08 15:50:48 [DEBUG] vertex 'root.root': walking
2017/03/08 15:50:48 [TRACE] ConfigTransformer: Starting for path: []
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.ConfigTransformer:

infoblox_ip.foo - *terraform.NodePlannableResource
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.OutputTransformer:

infoblox_ip.foo - *terraform.NodePlannableResource
output.next_available_ip - *terraform.NodeApplyableOutput
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.OrphanResourceTransformer:

infoblox_ip.foo - *terraform.NodePlannableResource
output.next_available_ip - *terraform.NodeApplyableOutput
2017/03/08 15:50:48 [TRACE] AttachResourceConfigTransformer: Beginning...
2017/03/08 15:50:48 [TRACE] AttachResourceConfigTransformer: Attach resource config request: infoblox_ip.foo
2017/03/08 15:50:48 [TRACE] Attaching resource config: &config.Resource{Mode:0, Name:"foo", Type:"infoblox_ip", RawCount:(*config.RawConfig)(0xc42047e720), RawConfig:(*config.RawConfig)(0xc42047e5a0), Provisioners:[]*config.Provisioner(nil), Provider:"", DependsOn:[]string(nil), Lifecycle:config.ResourceLifecycle{CreateBeforeDestroy:false, PreventDestroy:false, IgnoreChanges:[]string(nil)}}
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.AttachResourceConfigTransformer:

infoblox_ip.foo - *terraform.NodePlannableResource
output.next_available_ip - *terraform.NodeApplyableOutput
2017/03/08 15:50:48 [DEBUG] Resource state not found for "infoblox_ip.foo": infoblox_ip.foo
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.AttachStateTransformer:

infoblox_ip.foo - *terraform.NodePlannableResource
output.next_available_ip - *terraform.NodeApplyableOutput
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.RootVariableTransformer:

infoblox_ip.foo - *terraform.NodePlannableResource
output.next_available_ip - *terraform.NodeApplyableOutput
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.MissingProviderTransformer:

infoblox_ip.foo - *terraform.NodePlannableResource
output.next_available_ip - *terraform.NodeApplyableOutput
provider.infoblox - *terraform.NodeApplyableProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.ProviderTransformer:

infoblox_ip.foo - *terraform.NodePlannableResource
  provider.infoblox - *terraform.NodeApplyableProvider
output.next_available_ip - *terraform.NodeApplyableOutput
provider.infoblox - *terraform.NodeApplyableProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.DisableProviderTransformer:

infoblox_ip.foo - *terraform.NodePlannableResource
  provider.infoblox - *terraform.NodeApplyableProvider
output.next_available_ip - *terraform.NodeApplyableOutput
provider.infoblox - *terraform.NodeApplyableProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.ParentProviderTransformer:

infoblox_ip.foo - *terraform.NodePlannableResource
  provider.infoblox - *terraform.NodeApplyableProvider
output.next_available_ip - *terraform.NodeApplyableOutput
provider.infoblox - *terraform.NodeApplyableProvider
2017/03/08 15:50:48 [TRACE] Attach provider request: []string{} infoblox
2017/03/08 15:50:48 [TRACE] Attaching provider config: *config.ProviderConfig{Name:"infoblox", Alias:"", RawConfig:(*config.RawConfig)(0xc42047e3c0)}
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.AttachProviderConfigTransformer:

infoblox_ip.foo - *terraform.NodePlannableResource
  provider.infoblox - *terraform.NodeApplyableProvider
output.next_available_ip - *terraform.NodeApplyableOutput
provider.infoblox - *terraform.NodeApplyableProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.ModuleVariableTransformer:

infoblox_ip.foo - *terraform.NodePlannableResource
  provider.infoblox - *terraform.NodeApplyableProvider
output.next_available_ip - *terraform.NodeApplyableOutput
provider.infoblox - *terraform.NodeApplyableProvider
2017/03/08 15:50:48 [DEBUG] ReferenceTransformer: "infoblox_ip.foo" references: []
2017/03/08 15:50:48 [DEBUG] ReferenceTransformer: "output.next_available_ip" references: [infoblox_ip.foo]
2017/03/08 15:50:48 [DEBUG] ReferenceTransformer: "provider.infoblox" references: []
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.ReferenceTransformer:

infoblox_ip.foo - *terraform.NodePlannableResource
  provider.infoblox - *terraform.NodeApplyableProvider
output.next_available_ip - *terraform.NodeApplyableOutput
  infoblox_ip.foo - *terraform.NodePlannableResource
provider.infoblox - *terraform.NodeApplyableProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.TargetsTransformer:

infoblox_ip.foo - *terraform.NodePlannableResource
  provider.infoblox - *terraform.NodeApplyableProvider
output.next_available_ip - *terraform.NodeApplyableOutput
  infoblox_ip.foo - *terraform.NodePlannableResource
provider.infoblox - *terraform.NodeApplyableProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.RootTransformer:

infoblox_ip.foo - *terraform.NodePlannableResource
  provider.infoblox - *terraform.NodeApplyableProvider
output.next_available_ip - *terraform.NodeApplyableOutput
  infoblox_ip.foo - *terraform.NodePlannableResource
provider.infoblox - *terraform.NodeApplyableProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.TransitiveReductionTransformer:

infoblox_ip.foo - *terraform.NodePlannableResource
  provider.infoblox - *terraform.NodeApplyableProvider
output.next_available_ip - *terraform.NodeApplyableOutput
  infoblox_ip.foo - *terraform.NodePlannableResource
provider.infoblox - *terraform.NodeApplyableProvider
2017/03/08 15:50:48 [DEBUG] Starting graph walk: walkPlan
2017/03/08 15:50:48 [DEBUG] vertex 'root.provider.infoblox': walking
2017/03/08 15:50:48 [DEBUG] vertex 'root.provider.infoblox': evaluating
2017/03/08 15:50:48 [TRACE] [walkPlan] Entering eval tree: provider.infoblox
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalSequence
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalInitProvider
2017/03/08 15:50:48 [DEBUG] root: eval: terraform.EvalNoop
2017/03/08 15:50:48 [DEBUG] root: eval: terraform.EvalNoop
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalOpFilter
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalSequence
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalGetProvider
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalInterpolate
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalBuildProviderConfig
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalSetProviderConfig
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalOpFilter
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalSequence
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalConfigProvider
2017/03/08 15:50:48 [DEBUG] plugin: terraform-provider-infoblox: 2017/03/08 15:50:48 WARNING: SSL cert verification  disabled
2017/03/08 15:50:48 [DEBUG] plugin: terraform-provider-infoblox: 2017/03/08 15:50:48 [INFO] Infoblox Client configured for user: FabioAPI
2017/03/08 15:50:48 [TRACE] [walkPlan] Exiting eval tree: provider.infoblox
2017/03/08 15:50:48 [DEBUG] vertex "infoblox_ip.foo", got dep: "provider.infoblox"
2017/03/08 15:50:48 [DEBUG] vertex 'root.infoblox_ip.foo': walking
2017/03/08 15:50:48 [DEBUG] vertex 'root.infoblox_ip.foo': evaluating
2017/03/08 15:50:48 [TRACE] [walkPlan] Entering eval tree: infoblox_ip.foo
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalSequence
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalInterpolate
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalCountCheckComputed
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalCountFixZeroOneBoundary
2017/03/08 15:50:48 [TRACE] [walkPlan] Exiting eval tree: infoblox_ip.foo
2017/03/08 15:50:48 [DEBUG] vertex 'root.infoblox_ip.foo': expanding/walking dynamic subgraph
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.ResourceCountTransformer:

infoblox_ip.foo - *terraform.NodePlannableResourceInstance
2017/03/08 15:50:48 [TRACE] OrphanResourceCount: Starting...
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.OrphanResourceCountTransformer:

infoblox_ip.foo - *terraform.NodePlannableResourceInstance
2017/03/08 15:50:48 [DEBUG] Resource state not found for "infoblox_ip.foo": infoblox_ip.foo
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.AttachStateTransformer:

infoblox_ip.foo - *terraform.NodePlannableResourceInstance
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.TargetsTransformer:

infoblox_ip.foo - *terraform.NodePlannableResourceInstance
2017/03/08 15:50:48 [DEBUG] ReferenceTransformer: "infoblox_ip.foo" references: []
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.ReferenceTransformer:

infoblox_ip.foo - *terraform.NodePlannableResourceInstance
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.RootTransformer:

infoblox_ip.foo - *terraform.NodePlannableResourceInstance
2017/03/08 15:50:48 [DEBUG] vertex 'root.infoblox_ip.foo': walking
2017/03/08 15:50:48 [DEBUG] vertex 'root.infoblox_ip.foo': evaluating
2017/03/08 15:50:48 [TRACE] [walkPlan] Entering eval tree: infoblox_ip.foo
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalSequence
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalInterpolate
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalGetProvider
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalValidateResource
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalReadState
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalDiff
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalCheckPreventDestroy
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalWriteState
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalWriteDiff
2017/03/08 15:50:48 [TRACE] [walkPlan] Exiting eval tree: infoblox_ip.foo
2017/03/08 15:50:48 [DEBUG] vertex "output.next_available_ip", got dep: "infoblox_ip.foo"
2017/03/08 15:50:48 [DEBUG] vertex 'root.output.next_available_ip': walking
2017/03/08 15:50:48 [DEBUG] vertex 'root.output.next_available_ip': evaluating
2017/03/08 15:50:48 [TRACE] [walkPlan] Entering eval tree: output.next_available_ip
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalOpFilter
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalSequence
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalWriteOutput
2017/03/08 15:50:48 [TRACE] [walkPlan] Exiting eval tree: output.next_available_ip
2017/03/08 15:50:48 [TRACE] DiffTransformer: starting
2017/03/08 15:50:48 [TRACE] DiffTransformer: Module: CREATE: infoblox_ip.foo
  cidr:      "" => "1.2.3.4/24"
  ipaddress: "" => "<computed>"
2017/03/08 15:50:48 [TRACE] DiffTransformer: Resource "infoblox_ip.foo": *terraform.InstanceDiff{mu:sync.Mutex{state:0, sema:0x0}, Attributes:map[string]*terraform.ResourceAttrDiff{"cidr":*terraform.ResourceAttrDiff{Old:"", New:"1.2.3.4/24", NewComputed:false, NewRemoved:false, NewExtra:interface {}(nil), RequiresNew:false, Sensitive:false, Type:0x0}, "ipaddress":*terraform.ResourceAttrDiff{Old:"", New:"", NewComputed:true, NewRemoved:false, NewExtra:interface {}(nil), RequiresNew:false, Sensitive:false, Type:0x0}, "id":*terraform.ResourceAttrDiff{Old:"", New:"", NewComputed:true, NewRemoved:false, NewExtra:interface {}(nil), RequiresNew:true, Sensitive:false, Type:0x2}}, Destroy:false, DestroyDeposed:false, DestroyTainted:false}
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.DiffTransformer:

infoblox_ip.foo - *terraform.NodeApplyableResource
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.OrphanOutputTransformer:

infoblox_ip.foo - *terraform.NodeApplyableResource
2017/03/08 15:50:48 [TRACE] AttachResourceConfigTransformer: Beginning...
2017/03/08 15:50:48 [TRACE] AttachResourceConfigTransformer: Attach resource config request: infoblox_ip.foo
2017/03/08 15:50:48 [TRACE] Attaching resource config: &config.Resource{Mode:0, Name:"foo", Type:"infoblox_ip", RawCount:(*config.RawConfig)(0xc42047e720), RawConfig:(*config.RawConfig)(0xc42047e5a0), Provisioners:[]*config.Provisioner(nil), Provider:"", DependsOn:[]string(nil), Lifecycle:config.ResourceLifecycle{CreateBeforeDestroy:false, PreventDestroy:false, IgnoreChanges:[]string(nil)}}
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.AttachResourceConfigTransformer:

infoblox_ip.foo - *terraform.NodeApplyableResource
2017/03/08 15:50:48 [DEBUG] Resource state not found for "infoblox_ip.foo": infoblox_ip.foo
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.AttachStateTransformer:

infoblox_ip.foo - *terraform.NodeApplyableResource
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.MissingProviderTransformer:

infoblox_ip.foo - *terraform.NodeApplyableResource
provider.infoblox - *terraform.NodeApplyableProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.ProviderTransformer:

infoblox_ip.foo - *terraform.NodeApplyableResource
  provider.infoblox - *terraform.NodeApplyableProvider
provider.infoblox - *terraform.NodeApplyableProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.DisableProviderTransformer:

infoblox_ip.foo - *terraform.NodeApplyableResource
  provider.infoblox - *terraform.NodeApplyableProvider
provider.infoblox - *terraform.NodeApplyableProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.ParentProviderTransformer:

infoblox_ip.foo - *terraform.NodeApplyableResource
  provider.infoblox - *terraform.NodeApplyableProvider
provider.infoblox - *terraform.NodeApplyableProvider
2017/03/08 15:50:48 [TRACE] Attach provider request: []string{} infoblox
2017/03/08 15:50:48 [TRACE] Attaching provider config: *config.ProviderConfig{Name:"infoblox", Alias:"", RawConfig:(*config.RawConfig)(0xc42047e3c0)}
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.AttachProviderConfigTransformer:

infoblox_ip.foo - *terraform.NodeApplyableResource
  provider.infoblox - *terraform.NodeApplyableProvider
provider.infoblox - *terraform.NodeApplyableProvider
2017/03/08 15:50:48 [TRACE] DestroyEdgeTransformer: Beginning destroy edge transformation...
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.DestroyEdgeTransformer:

infoblox_ip.foo - *terraform.NodeApplyableResource
  provider.infoblox - *terraform.NodeApplyableProvider
provider.infoblox - *terraform.NodeApplyableProvider
2017/03/08 15:50:48 [TRACE] CBDEdgeTransformer: Beginning CBD transformation...
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.CBDEdgeTransformer:

infoblox_ip.foo - *terraform.NodeApplyableResource
  provider.infoblox - *terraform.NodeApplyableProvider
provider.infoblox - *terraform.NodeApplyableProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.graphTransformerMulti:

infoblox_ip.foo - *terraform.NodeApplyableResource
  provider.infoblox - *terraform.NodeApplyableProvider
provider.infoblox - *terraform.NodeApplyableProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.RootVariableTransformer:

infoblox_ip.foo - *terraform.NodeApplyableResource
  provider.infoblox - *terraform.NodeApplyableProvider
provider.infoblox - *terraform.NodeApplyableProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.OutputTransformer:

infoblox_ip.foo - *terraform.NodeApplyableResource
  provider.infoblox - *terraform.NodeApplyableProvider
output.next_available_ip - *terraform.NodeApplyableOutput
provider.infoblox - *terraform.NodeApplyableProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.ModuleVariableTransformer:

infoblox_ip.foo - *terraform.NodeApplyableResource
  provider.infoblox - *terraform.NodeApplyableProvider
output.next_available_ip - *terraform.NodeApplyableOutput
provider.infoblox - *terraform.NodeApplyableProvider
2017/03/08 15:50:48 [DEBUG] ReferenceTransformer: "infoblox_ip.foo" references: []
2017/03/08 15:50:48 [DEBUG] ReferenceTransformer: "provider.infoblox" references: []
2017/03/08 15:50:48 [DEBUG] ReferenceTransformer: "output.next_available_ip" references: [infoblox_ip.foo]
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.ReferenceTransformer:

infoblox_ip.foo - *terraform.NodeApplyableResource
  provider.infoblox - *terraform.NodeApplyableProvider
output.next_available_ip - *terraform.NodeApplyableOutput
  infoblox_ip.foo - *terraform.NodeApplyableResource
provider.infoblox - *terraform.NodeApplyableProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.CountBoundaryTransformer:

infoblox_ip.foo - *terraform.NodeApplyableResource
  provider.infoblox - *terraform.NodeApplyableProvider
meta.count-boundary (count boundary fixup) - *terraform.NodeCountBoundary
  infoblox_ip.foo - *terraform.NodeApplyableResource
  output.next_available_ip - *terraform.NodeApplyableOutput
  provider.infoblox - *terraform.NodeApplyableProvider
output.next_available_ip - *terraform.NodeApplyableOutput
  infoblox_ip.foo - *terraform.NodeApplyableResource
provider.infoblox - *terraform.NodeApplyableProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.TargetsTransformer:

infoblox_ip.foo - *terraform.NodeApplyableResource
  provider.infoblox - *terraform.NodeApplyableProvider
meta.count-boundary (count boundary fixup) - *terraform.NodeCountBoundary
  infoblox_ip.foo - *terraform.NodeApplyableResource
  output.next_available_ip - *terraform.NodeApplyableOutput
  provider.infoblox - *terraform.NodeApplyableProvider
output.next_available_ip - *terraform.NodeApplyableOutput
  infoblox_ip.foo - *terraform.NodeApplyableResource
provider.infoblox - *terraform.NodeApplyableProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.RootTransformer:

infoblox_ip.foo - *terraform.NodeApplyableResource
  provider.infoblox - *terraform.NodeApplyableProvider
meta.count-boundary (count boundary fixup) - *terraform.NodeCountBoundary
  infoblox_ip.foo - *terraform.NodeApplyableResource
  output.next_available_ip - *terraform.NodeApplyableOutput
  provider.infoblox - *terraform.NodeApplyableProvider
output.next_available_ip - *terraform.NodeApplyableOutput
  infoblox_ip.foo - *terraform.NodeApplyableResource
provider.infoblox - *terraform.NodeApplyableProvider
2017/03/08 15:50:48 [TRACE] Graph after step *terraform.TransitiveReductionTransformer:

infoblox_ip.foo - *terraform.NodeApplyableResource
  provider.infoblox - *terraform.NodeApplyableProvider
meta.count-boundary (count boundary fixup) - *terraform.NodeCountBoundary
  output.next_available_ip - *terraform.NodeApplyableOutput
output.next_available_ip - *terraform.NodeApplyableOutput
  infoblox_ip.foo - *terraform.NodeApplyableResource
provider.infoblox - *terraform.NodeApplyableProvider
2017/03/08 15:50:48 [DEBUG] Starting graph walk: walkApply
2017/03/08 15:50:48 [DEBUG] vertex 'root.provider.infoblox': walking
2017/03/08 15:50:48 [DEBUG] vertex 'root.provider.infoblox': evaluating
2017/03/08 15:50:48 [TRACE] [walkApply] Entering eval tree: provider.infoblox
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalSequence
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalInitProvider
2017/03/08 15:50:48 [DEBUG] root: eval: terraform.EvalNoop
2017/03/08 15:50:48 [DEBUG] root: eval: terraform.EvalNoop
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalOpFilter
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalSequence
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalGetProvider
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalInterpolate
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalBuildProviderConfig
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalSetProviderConfig
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalOpFilter
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalSequence
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalConfigProvider
2017/03/08 15:50:48 [DEBUG] plugin: terraform-provider-infoblox: 2017/03/08 15:50:48 WARNING: SSL cert verification  disabled
2017/03/08 15:50:48 [DEBUG] plugin: terraform-provider-infoblox: 2017/03/08 15:50:48 [INFO] Infoblox Client configured for user: FabioAPI
2017/03/08 15:50:48 [TRACE] [walkApply] Exiting eval tree: provider.infoblox
2017/03/08 15:50:48 [DEBUG] vertex "infoblox_ip.foo", got dep: "provider.infoblox"
2017/03/08 15:50:48 [DEBUG] vertex 'root.infoblox_ip.foo': walking
2017/03/08 15:50:48 [DEBUG] vertex 'root.infoblox_ip.foo': evaluating
2017/03/08 15:50:48 [TRACE] [walkApply] Entering eval tree: infoblox_ip.foo
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalSequence
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalInstanceInfo
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalReadDiff
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalIf
2017/03/08 15:50:48 [DEBUG] root: eval: terraform.EvalNoop
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalIf
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalInterpolate
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalGetProvider
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalReadState
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalValidateResource
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalDiff
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalReadDiff
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalCompareDiff
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalGetProvider
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalReadState
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalApply
2017/03/08 15:50:48 [DEBUG] apply: infoblox_ip.foo: executing Apply
2017/03/08 15:50:48 [DEBUG] plugin: terraform-provider-infoblox: 2017/03/08 15:50:48 [TRACE] inside resourceInfobloxIPCreate.
2017/03/08 15:50:48 [DEBUG] plugin: terraform-provider-infoblox: 2017/03/08 15:50:48 [TRACE] CIDR from terraform file: 1.2.3.4/24
2017/03/08 15:50:48 [DEBUG] plugin: terraform-provider-infoblox: 2017/03/08 15:50:48 [TRACE] invoking client.Network().find
2017/03/08 15:50:48 [DEBUG] plugin: terraform-provider-infoblox: 2017/03/08 15:50:48 GET /wapi/v1.4.1/network?network=1.2.3.4%2F24  payload:
2017/03/08 15:50:48 [DEBUG] plugin: terraform-provider-infoblox: 2017/03/08 15:50:48 [TRACE] invoking client.NetworkObject().NextAvailableIP
2017/03/08 15:50:48 [DEBUG] plugin: terraform-provider-infoblox: panic: runtime error: index out of range
2017/03/08 15:50:48 [DEBUG] plugin: terraform-provider-infoblox:
2017/03/08 15:50:48 [DEBUG] plugin: terraform-provider-infoblox: goroutine 82 [running]:
2017/03/08 15:50:48 [DEBUG] plugin: terraform-provider-infoblox: panic(0x5ad740, 0xc42000c150)
2017/03/08 15:50:48 [DEBUG] plugin: terraform-provider-infoblox: 	/usr/local/Cellar/go/1.7.4_2/libexec/src/runtime/panic.go:500 +0x1a1
2017/03/08 15:50:48 [DEBUG] plugin: terraform-provider-infoblox: github.com/prudhvitella/terraform-provider-infoblox/infoblox.resourceInfobloxIPCreate(0xc42023a480, 0x63f960, 0xc4202db740, 0x5b4300, 0xc784)
2017/03/08 15:50:48 [DEBUG] plugin: terraform-provider-infoblox: 	/Users/jack/go/src/github.com/prudhvitella/terraform-provider-infoblox/infoblox/resource_infoblox_ip.go:113 +0xd66
2017/03/08 15:50:48 [DEBUG] plugin: terraform-provider-infoblox: github.com/hashicorp/terraform/helper/schema.(*Resource).Apply(0xc4202dc540, 0xc42011c2d0, 0xc420124580, 0x63f960, 0xc4202db740, 0x1, 0xc42011e7b0, 0x0)
2017/03/08 15:50:48 [DEBUG] plugin: terraform-provider-infoblox: 	/Users/jack/go/src/github.com/hashicorp/terraform/helper/schema/resource.go:162 +0x30e
2017/03/08 15:50:48 [DEBUG] plugin: terraform-provider-infoblox: github.com/hashicorp/terraform/helper/schema.(*Provider).Apply(0xc4202dc5a0, 0xc42011c280, 0xc42011c2d0, 0xc420124580, 0x0, 0x18, 0x18)
2017/03/08 15:50:48 [DEBUG] plugin: terraform-provider-infoblox: 	/Users/jack/go/src/github.com/hashicorp/terraform/helper/schema/provider.go:212 +0x9b
2017/03/08 15:50:48 [DEBUG] plugin: terraform-provider-infoblox: github.com/hashicorp/terraform/plugin.(*ResourceProviderServer).Apply(0xc420245c60, 0xc420124080, 0xc420120490, 0x0, 0x0)
2017/03/08 15:50:48 [DEBUG] plugin: terraform-provider-infoblox: 	/Users/jack/go/src/github.com/hashicorp/terraform/plugin/resource_provider.go:488 +0x57
2017/03/08 15:50:48 [DEBUG] plugin: terraform-provider-infoblox: reflect.Value.call(0xc420216ae0, 0xc42012e9c0, 0x13, 0x64f808, 0x4, 0xc4202c5ee0, 0x3, 0x3, 0xe7e28, 0x954b00, ...)
2017/03/08 15:50:48 [DEBUG] plugin: terraform-provider-infoblox: 	/usr/local/Cellar/go/1.7.4_2/libexec/src/reflect/value.go:434 +0x5c8
2017/03/08 15:50:48 [DEBUG] plugin: terraform-provider-infoblox: reflect.Value.Call(0xc420216ae0, 0xc42012e9c0, 0x13, 0xc4202c5ee0, 0x3, 0x3, 0x170d57, 0xc4201200d0, 0xc)
2017/03/08 15:50:48 [DEBUG] plugin: terraform-provider-infoblox: 	/usr/local/Cellar/go/1.7.4_2/libexec/src/reflect/value.go:302 +0xa4
2017/03/08 15:50:48 [DEBUG] plugin: terraform-provider-infoblox: net/rpc.(*service).call(0xc4202dadc0, 0xc4202dad80, 0xc4202ee560, 0xc4202ea180, 0xc4202d5400, 0x552960, 0xc420124080, 0x16, 0x5529a0, 0xc420120490, ...)
2017/03/08 15:50:48 [DEBUG] plugin: terraform-provider-infoblox: 	/usr/local/Cellar/go/1.7.4_2/libexec/src/net/rpc/server.go:383 +0x148
2017/03/08 15:50:48 [DEBUG] plugin: terraform-provider-infoblox: created by net/rpc.(*Server).ServeCodec
2017/03/08 15:50:48 [DEBUG] plugin: terraform-provider-infoblox: 	/usr/local/Cellar/go/1.7.4_2/libexec/src/net/rpc/server.go:477 +0x421
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalWriteState
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalApplyProvisioners
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalIf
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalWriteState
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalWriteDiff
2017/03/08 15:50:48 [DEBUG] root: eval: *terraform.EvalApplyPost
2017/03/08 15:50:48 [ERROR] root: eval: *terraform.EvalApplyPost, err: 1 error(s) occurred:

* infoblox_ip.foo: unexpected EOF
2017/03/08 15:50:48 [ERROR] root: eval: *terraform.EvalSequence, err: 1 error(s) occurred:

* infoblox_ip.foo: unexpected EOF
2017/03/08 15:50:48 [TRACE] [walkApply] Exiting eval tree: infoblox_ip.foo
2017/03/08 15:50:48 [DEBUG] vertex "output.next_available_ip", got dep: "infoblox_ip.foo"
2017/03/08 15:50:48 [DEBUG] vertex "meta.count-boundary (count boundary fixup)", got dep: "output.next_available_ip"
2017/03/08 15:50:48 [DEBUG] plugin: /usr/local/bin/terraform-provider-infoblox: plugin process exited
2017/03/08 15:50:48 [TRACE] Preserving existing state lineage "54f8b580-f479-43e8-89bb-037d786b69e9"
2017/03/08 15:50:48 [TRACE] Preserving existing state lineage "54f8b580-f479-43e8-89bb-037d786b69e9"
2017/03/08 15:50:48 [DEBUG] plugin: waiting for all plugin processes to complete...
2017/03/08 15:50:48 [WARN] plugin: error closing client during Kill: connection is shut down
```