### PR TITLE
Allow IP range

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ that can be used by the infoblox_record resource.
 
 ```
 # Acquire the next available IP from a network CIDR
-#it will create a variable called "ipaddress"
+# it will create a variable called "ipaddress"
 resource "infoblox_ip" "theIPAddress" {
 	cidr = "10.0.0.0/24"
 }
@@ -116,10 +116,31 @@ resource "infoblox_record" "foobar" {
 	type = "A"
 	ttl = 3600
 }
+
+# Exclude specific IP addresses when acquiring next
+# avaiable IP from a network CIDR
+resource "infoblox_ip" "excludedIPAddress" {
+    cidr = "10.0.0.0/24"
+
+    exclude = [
+        "10.0.0.1",
+        "10.0.0.2"
+        # etc.
+    ]
+}
+
+# Acquire gree IP address from within a specific
+# range of addresses
+resource "infoblox_ip" "ipAddressFromRange" {
+    ip_range = "10.0.0.20-10.0.0.60"
+}
 ```
 
 ## Argument Reference
 
 The following arguments are supported:
 
-* `cidr` - (Required) The network to search for - example 10.0.0.0/24
+* `cidr` - (Required) The network to search for - example 10.0.0.0/24. Cannot be specified with `ip\_range`
+* `exclude` - (Optional) A list of IP addresses to exclude
+* `ip\_range` - (Required) The IP range to search within - example 10.0.0.20-10.0.0.40. Cannot be
+  specified with `cidr`

--- a/infoblox/helpers.go
+++ b/infoblox/helpers.go
@@ -1,0 +1,88 @@
+package infoblox
+
+import (
+	"fmt"
+	"github.com/fanatic/go-infoblox"
+	"github.com/hashicorp/terraform/helper/schema"
+	"log"
+	"strings"
+)
+
+func getNetworkNameFromIP(response []map[string]interface{}, err error) string {
+	e(err)
+
+	for _, v := range response {
+		for k, val := range v {
+			if k == "network" {
+				return val.(string)
+			}
+		}
+	}
+
+	return ""
+}
+
+func getNetwork(client *infoblox.Client, term string) ([]map[string]interface{}, error) {
+	s := "network"
+	q := []infoblox.Condition{
+		infoblox.Condition{
+			Field: &s,
+			Value: term,
+		},
+	}
+
+	network, err := client.Network().Find(q, nil)
+	return network, err
+}
+
+func getStartingIP(ip_range string) string {
+	return strings.Split(ip_range, "-")[0]
+}
+
+func buildExcludedAddressesArray(d *schema.ResourceData) []string {
+	var excludedAddresses []string
+	if userExcludes := d.Get("exclude"); userExcludes != nil {
+		addresses := userExcludes.(*schema.Set).List()
+		for _, address := range addresses {
+			excludedAddresses = append(excludedAddresses, address.(string))
+		}
+	}
+	return excludedAddresses
+}
+
+// TODO: I'm positive there's a better way to do this, but this works for now
+func getMapValueAsString(mymap map[string]interface{}, val string) string {
+	for k, v := range mymap {
+		if k == val {
+			vout := fmt.Sprintf("%q", v)
+			vout = strings.Replace(vout, "[", "", -1)
+			vout = strings.Replace(vout, "]", "", -1)
+			vout = strings.Replace(vout, "\"", "", -1)
+			return vout
+		}
+	}
+
+	return ""
+}
+
+func printList(out []map[string]interface{}, err error) {
+	e(err)
+	for i, v := range out {
+		log.Printf("[%d]\n", i)
+		printObject(v, nil)
+	}
+}
+
+func printObject(out map[string]interface{}, err error) {
+	e(err)
+	for k, v := range out {
+		log.Printf("  %s: %q\n", k, v)
+	}
+	log.Printf("\n")
+}
+
+func e(err error) {
+	if err != nil {
+		log.Printf("Error: %v\n", err)
+	}
+}

--- a/infoblox/resource_infoblox_ip.go
+++ b/infoblox/resource_infoblox_ip.go
@@ -49,8 +49,6 @@ import (
 	"fmt"
 	"github.com/fanatic/go-infoblox"
 	"github.com/hashicorp/terraform/helper/schema"
-	"log"
-	"strings"
 )
 
 func resourceInfobloxIP() *schema.Resource {
@@ -63,8 +61,15 @@ func resourceInfobloxIP() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"cidr": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: false,
+			},
+
+			"ip_range": &schema.Schema{
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      false,
+				ConflictsWith: []string{"cidr"},
 			},
 
 			"ipaddress": &schema.Schema{
@@ -82,118 +87,95 @@ func resourceInfobloxIP() *schema.Resource {
 	}
 }
 
-func resourceInfobloxIPCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*infoblox.Client)
+func getNextAvailableIPFromCIDR(client *infoblox.Client, cidr string, excludedAddresses []string) (string, error) {
+	var (
+		err    error
+		result string
+		ou     map[string]interface{}
+	)
 
-	log.Print("[TRACE] inside resourceInfobloxIPCreate.")
+	network, err := getNetwork(client, cidr)
 
-	ntwork := d.Get("cidr")
-
-	log.Printf("[TRACE] CIDR from terraform file: %s", ntwork.(string))
-
-	s := "network"
-	q := []infoblox.Condition{
-		infoblox.Condition{
-			Field: &s,
-			Value: ntwork.(string),
-		},
+	if len(network) == 0 {
+		err = fmt.Errorf("[ERROR] Empty response from client.Network().find. Is %s a valid network?", cidr)
 	}
 
-	log.Print("[TRACE] invoking client.Network().find")
-
-	out, err := client.Network().Find(q, nil)
-
-	if err != nil {
-		log.Printf("[ERROR] Unable to invoke find on cidr: %s, %s", ntwork, err)
-		return err
-	}
-
-	if len(out) == 0 {
-		return fmt.Errorf("Empty response from client.Network().find. Is %s a valid network?", ntwork)
-	}
-
-	printList(out, nil)
-
-	log.Print("[TRACE] invoking client.NetworkObject().NextAvailableIP")
-
-	var excludedAddresses []string
-	if userExcludes := d.Get("exclude"); userExcludes != nil {
-		addresses := userExcludes.(*schema.Set).List()
-		for _, address := range addresses {
-			excludedAddresses = append(excludedAddresses, address.(string))
+	if err == nil {
+		ou, err = client.NetworkObject(network[0]["_ref"].(string)).NextAvailableIP(1, excludedAddresses)
+		result = getMapValueAsString(ou, "ips")
+		if result == "" {
+			err = fmt.Errorf("Error: unable to determine IP address from response.\n")
 		}
 	}
 
-	log.Printf("[TRACE] Excluding Addresses = %v", excludedAddresses)
+	return result, err
+}
 
-	ou, err := client.NetworkObject(out[0]["_ref"].(string)).NextAvailableIP(1, excludedAddresses)
+func getNextAvailableIPFromRange(client *infoblox.Client, ip_range string, excludedAddresses []string) (string, error) {
+	var (
+		err    error
+		result string
+		ou     map[string]interface{}
+	)
 
-	if err != nil {
-		log.Printf("[ERROR] Unable to allocate NextAvailableIP: %s", err)
+	s := "ip_address"
+	q := []infoblox.Condition{
+		infoblox.Condition{
+			Field: &s,
+			Value: getStartingIP(ip_range),
+		},
+	}
+
+	out, err := client.Ipv4address().Find(q, nil)
+	networkName := getNetworkNameFromIP(out, err)
+	network, err := getNetwork(client, networkName)
+
+	if err == nil {
+		ou, err = client.NetworkObject(network[0]["_ref"].(string)).NextAvailableIP(1, excludedAddresses)
+		result = getMapValueAsString(ou, "ips")
+	}
+
+	return result, err
+}
+
+func resourceInfobloxIPCreate(d *schema.ResourceData, meta interface{}) error {
+	if err := validateIPData(d); err != nil {
 		return err
 	}
 
-	printObject(ou, nil)
+	var (
+		result string
+		err    error
+	)
 
-	log.Print("[TRACE] Walking NextAvailableIP output to get ip")
+	client := meta.(*infoblox.Client)
+	excludedAddresses := buildExcludedAddressesArray(d)
 
-	res := getMapValueAsString(ou, "ips")
-
-	if res == "" {
-		log.Print("Error: unable to determine IP address from response \n", err)
-		return nil
+	if cidr, ok := d.GetOk("cidr"); ok {
+		result, err = getNextAvailableIPFromCIDR(client, cidr.(string), excludedAddresses)
+	} else if ip_range, ok := d.GetOk("ip_range"); ok {
+		result, err = getNextAvailableIPFromRange(client, ip_range.(string), excludedAddresses)
 	}
 
-	log.Printf("[TRACE] returned value in ips structure: %s", res)
+	if err != nil {
+		return err
+	}
 
-	log.Print("[TRACE] Setting ID, locking provisioned IP in terraform")
-
-	d.SetId(res)
-
-	log.Print("[TRACE] Setting output variable 'ipaddress'")
-
-	d.Set("ipaddress", res)
-
-	log.Print("[TRACE] exiting resourceInfobloxIPCreate.")
+	d.SetId(result)
+	d.Set("ipaddress", result)
 
 	return nil
 }
 
-// TODO: I'm positive there's a better way to do this, but this works for now
-func getMapValueAsString(mymap map[string]interface{}, val string) string {
-	for k, v := range mymap {
-		if k == val {
-			vout := fmt.Sprintf("%q", v)
-			vout = strings.Replace(vout, "[", "", -1)
-			vout = strings.Replace(vout, "]", "", -1)
-			vout = strings.Replace(vout, "\"", "", -1)
-			return vout
-		}
+// Validates that either 'cidr' or 'ip_range' is set
+func validateIPData(d *schema.ResourceData) error {
+	_, cidrOk := d.GetOk("cidr")
+	_, ipRangeOk := d.GetOk("ip_range")
+	if !cidrOk && !ipRangeOk {
+		return fmt.Errorf(
+			"One of ['cidr', 'ip_range'] must be set to create an Infoblox IP")
 	}
-
-	return ""
-}
-
-func printList(out []map[string]interface{}, err error) {
-	e(err)
-	for i, v := range out {
-		log.Printf("[%d]\n", i)
-		printObject(v, nil)
-	}
-}
-
-func printObject(out map[string]interface{}, err error) {
-	e(err)
-	for k, v := range out {
-		log.Printf("  %s: %q\n", k, v)
-	}
-	log.Printf("\n")
-}
-
-func e(err error) {
-	if err != nil {
-		log.Printf("Error: %v\n", err)
-	}
+	return nil
 }
 
 func resourceInfobloxIPRead(d *schema.ResourceData, meta interface{}) error {

--- a/infoblox/resource_infoblox_ip.go
+++ b/infoblox/resource_infoblox_ip.go
@@ -124,7 +124,7 @@ func getNextAvailableIPFromCIDR(client *infoblox.Client, cidr string, excludedAd
 		ou     map[string]interface{}
 	)
 
-	network, err := getNetwork(client, cidr)
+	network, err := getNetworks(client, cidr)
 
 	if len(network) == 0 {
 		err = fmt.Errorf("[ERROR] Empty response from client.Network().find. Is %s a valid network?", cidr)

--- a/infoblox/resource_infoblox_ip.go
+++ b/infoblox/resource_infoblox_ip.go
@@ -103,8 +103,8 @@ func resourceInfobloxIPCreate(d *schema.ResourceData, meta interface{}) error {
 
 	if cidr, ok := d.GetOk("cidr"); ok {
 		result, err = getNextAvailableIPFromCIDR(client, cidr.(string), excludedAddresses)
-	} else if ip_range, ok := d.GetOk("ip_range"); ok {
-		result, err = getNextAvailableIPFromRange(client, ip_range.(string))
+	} else if ipRange, ok := d.GetOk("ip_range"); ok {
+		result, err = getNextAvailableIPFromRange(client, ipRange.(string))
 	}
 
 	if err != nil {
@@ -134,22 +134,22 @@ func getNextAvailableIPFromCIDR(client *infoblox.Client, cidr string, excludedAd
 		ou, err = client.NetworkObject(network[0]["_ref"].(string)).NextAvailableIP(1, excludedAddresses)
 		result = getMapValueAsString(ou, "ips")
 		if result == "" {
-			err = fmt.Errorf("Error: unable to determine IP address from response.\n")
+			err = fmt.Errorf("[ERROR] Unable to determine IP address from response")
 		}
 	}
 
 	return result, err
 }
 
-func getNextAvailableIPFromRange(client *infoblox.Client, ip_range string) (string, error) {
+func getNextAvailableIPFromRange(client *infoblox.Client, ipRange string) (string, error) {
 	var (
 		result string
 		err    error
 	)
 
-	ips := strings.Split(ip_range, "-")
+	ips := strings.Split(ipRange, "-")
 	if len(ips) != 2 {
-		return "", fmt.Errorf("[ERROR] ip_range must be of format <ipv4 addresss>-<ipv4 address>. Instead found: %s", ip_range)
+		return "", fmt.Errorf("[ERROR] ip_range must be of format <ipv4 addresss>-<ipv4 address>. Instead found: %s", ipRange)
 	}
 
 	ou, err := client.FindUnusedIPInRange(ips[0], ips[1])

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -177,10 +177,10 @@
 			"revisionTime": "2016-10-29T20:57:26Z"
 		},
 		{
-			"checksumSHA1": "yi87uDYpNzJ+az7anakAkm+zwCA=",
+			"checksumSHA1": "5bsYJYb0J8qVLnHwtPWCFUTmSo4=",
 			"path": "github.com/fanatic/go-infoblox",
-			"revision": "c1d3d28ef1c344834b5279b07e851bcd98f3c998",
-			"revisionTime": "2017-03-07T22:12:58Z"
+			"revision": "81fb1b02c381047011f80483457dee9de5d105fa",
+			"revisionTime": "2017-03-25T00:40:47Z"
 		},
 		{
 			"checksumSHA1": "Cu67hH9Sg86TBZb4An5owwfzEN0=",


### PR DESCRIPTION
Allows the use of an IP range instead of a network CIDR when creating an IPv4 address. Depends on https://github.com/fanatic/go-infoblox/pull/28

I'm very new to go so welcome any feedback at all.