### PR TITLE
add type assertion check to handleReadError

### DIFF
--- a/infoblox/resource_infoblox_record.go
+++ b/infoblox/resource_infoblox_record.go
@@ -98,9 +98,11 @@ func resourceInfobloxRecordCreate(d *schema.ResourceData, meta interface{}) erro
 }
 
 func handleReadError(d *schema.ResourceData, record_type string, err error) error {
-	if err.(infoblox.Error).Code() == "Client.Ibap.Data.NotFound" {
-		d.SetId("")
-		return nil
+	if infobloxErr, ok := err.(infoblox.Error); ok {
+		if infobloxErr.Code() == "Client.Ibap.Data.NotFound" {
+			d.SetId("")
+			return nil
+		}
 	}
 	return fmt.Errorf("Error reading Infoblox %s record: %s", record_type, err)
 }


### PR DESCRIPTION
Fixes #23 

Reports the actual error message rather than a panic when errors are not of type `infoblox.Error`. 