### PR TITLE
Split up dns record types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_install:
   - go get github.com/tcnksm/ghr
   - go get github.com/davecgh/go-spew/spew
   - go get github.com/hashicorp/logutils
+  - go get -u github.com/fanatic/go-infoblox
   - go get -u github.com/kardianos/govendor
   - govendor sync
 after_success:

--- a/README.md
+++ b/README.md
@@ -195,6 +195,58 @@ The following arguments are supported:
 * `ttl` - (Integer, Optional) The TTL of the record
 * `view` - (Optional) The view of the record
 
+# infoblox\_record\_txt
+
+Provides an Infoblox TXT record resource.
+
+## Example Usage
+
+```hcl
+resource "infoblox_record_txt" "txt" {
+  name = "some.fqdn.lan"
+  text = "Welcome to the Jungle"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required)  The name of the TXT record
+* `text` - (Required) The text of the TXT record
+* `comment` - (Optional) The comment for the record
+* `ttl` - (Integer, Optional) The TTL of the record
+* `view` - (Optional) The view of the record
+
+# infoblox\_record\_srv
+
+Provides an Infoblox SRV record resource.
+
+## Example Usage
+
+```hcl
+resource "infoblox_record_srv" "srv" {
+  name = "bind_srv.domain.com"
+  port = 1234
+  priority = 1
+  weight = 1
+  target = "old.target.test.org"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required)  The name of the record
+* `port` - (Integer, Required) The port of the SRV record
+* `priority` - (Integer, Required) The priority of the SRV record
+* `weight` - (Integer, Required) The weight of the SRV record
+* `target` - (Required) The target of the SRV record
+* `comment` - (Optional) The comment for the record
+* `ttl` - (Integer, Optional) The TTL of the record
+* `view` - (Optional) The view of the record
+
 # infoblox\_ip
 
 Queries the next available IP address from a network and returns it in a computed variable

--- a/README.md
+++ b/README.md
@@ -1,18 +1,19 @@
+# [Terraform](https://github.com/hashicorp/terraform) Infoblox Provider
+
 [![Build
 status](https://travis-ci.org/prudhvitella/terraform-provider-infoblox.svg)](https://travis-ci.org/prudhvitella/terraform-provider-infoblox)
-
-# [Terraform](https://github.com/hashicorp/terraform) Infoblox Provider
 
 The Infoblox provider is used to interact with the
 resources supported by Infoblox. The provider needs to be configured
 with the proper credentials before it can be used.
 
-##  Download
+## Download
+
 Download builds for Darwin, Linux and Windows from the [releases page](https://github.com/prudhvitella/terraform-provider-infoblox/releases/).
 
 ## Example Usage
 
-```
+```hcl
 # Configure the Infoblox provider
 provider "infoblox" {
     username = "${var.infoblox_username}"
@@ -38,13 +39,60 @@ The following arguments are supported:
 * `sslverify` - (Required) Enable ssl for the REST api, but it can also be sourced from the `INFOBLOX_SSLVERIFY` environment variable.
 * `usecookies` - (Optional) Use cookies to connect to the REST API, but it can also be sourced from the `INFOBLOX_USECOOKIES` environment variable
 
+# infoblox\_record\_host
+
+Provides an Infoblox Host record resource.
+
+## Example Usage
+
+```hcl
+resource "infoblox_record_host" "host" {
+  name              = "terraformhost.platform.test-aib.pri"
+  configure_for_dns = false
+
+  ipv4addr {
+    address = "10.89.130.30"
+  }
+
+  ipv4addr {
+    address            = "10.89.130.31"
+    configure_for_dhcp = true
+    mac                = "01-23-45-67-89-10"
+  }
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) The name of the record
+* `ipv4addr` - (Required) An IPv4 address object. At least one `iv4addr` or `ipv6addr` must be specified. See [ipv4addr options](#Ipv4addr_options) below.
+* `ipv6addr` - (Required) An IPv6 address object. At least one `iv4addr` or `ipv6addr` must be specified. See [ipv6addr options](#Ipv6addr_options) below.
+* `configure_for_dns` - (Boolean, Optional) Specify whether DNS should be configured for the record; defaults to `false`
+* `comment` - (Optional) The comment for the record
+* `ttl` - (Integer, Optional) The TTL of the record
+* `view` - (Optional) The view of the record
+
+### Ipv4 options
+
+* `address` - (Required) The IPv4 address of the object
+* `configure_for_dhcp` - (Boolean, Optional) Specifies whether the IPv4 address object should be configured for DHCP
+* `mac` - (Optional) The MAC address of the resource
+* `host` - (Optional) The Host of the resource
+
+### Ipv6 options
+
+* `address` - (Required) The IPv6 address of the object
+* `configure_for_dhcp` - (Boolean, Optional) Specifies whether the IPv4 address object should be configured for DHCP
+* `mac` - (Optional) The MAC address of the resource
+* `host` - (Optional) The Host of the resource
+
 # infoblox\_record\_a
 
 Provides an Infoblox A record resource.
 
 ## Example Usage
 
-```
+```hcl
 resource "infoblox_record_a" "web" {
   address = "10.1.2.3"
   name    = "some.fqdn.lan"
@@ -71,7 +119,7 @@ Provides an Infoblox AAAA record resource.
 
 ## Example Usage
 
-```
+```hcl
 resource "infoblox_record_aaaa" "web" {
   address = "2001:db8:85a3::8a2e:370:7334"
   name    = "some.fqdn.lan"
@@ -98,7 +146,7 @@ Provides an Infoblox CNAME record resource.
 
 ## Example Usage
 
-```
+```hcl
 resource "infoblox_record_cname" "www" {
   canonical = "fqdn.lan"
   name      = "www.fqdn.lan"
@@ -125,7 +173,7 @@ Provides an Infoblox PTR record resource.
 
 ## Example Usage
 
-```
+```hcl
 resource "infoblox_record_ptr" "ptr" {
   ptrdname = "some.fqdn.lan"
   address  = "10.0.0.10.in-addr.arpa"
@@ -154,11 +202,11 @@ that can be used by the infoblox_record resource.
 
 ## Example Usage
 
-```
+```hcl
 # Acquire the next available IP from a network CIDR
 # it will create a variable called "ipaddress"
 resource "infoblox_ip" "ip" {
-	cidr = "10.0.0.0/24"
+  cidr = "10.0.0.0/24"
 }
 
 resource "infoblox_record_a" "web" {
@@ -173,19 +221,19 @@ resource "infoblox_record_a" "web" {
 # Exclude specific IP addresses when acquiring next
 # avaiable IP from a network CIDR
 resource "infoblox_ip" "excludedIPAddress" {
-    cidr = "10.0.0.0/24"
+  cidr = "10.0.0.0/24"
 
-    exclude = [
-        "10.0.0.1",
-        "10.0.0.2"
-        # etc.
-    ]
+  exclude = [
+    "10.0.0.1",
+    "10.0.0.2"
+    # etc.
+  ]
 }
 
 # Acquire free IP address from within a specific
 # range of addresses
 resource "infoblox_ip" "ipAddressFromRange" {
-    ip_range = "10.0.0.20-10.0.0.60"
+  ip_range = "10.0.0.20-10.0.0.60"
 }
 ```
 
@@ -198,7 +246,6 @@ The following arguments are supported:
 * `ip_range` - (Required) The IP range to search within - example 10.0.0.20-10.0.0.40. Cannot be
   specified with `cidr`
 
-
 # Deprecated Resources
 
 The following resources are deprecated and will no longer see active development. It is recommended you use the dedicated `infoblox_record_*` resources instead.
@@ -209,14 +256,14 @@ Provides a Infoblox record resource.
 
 ### Example Usage
 
-```
+```hcl
 # Add a record to the domain
 resource "infoblox_record" "foobar" {
-	value = "192.168.0.10"
-	name = "terraform"
-	domain = "mydomain.com"
-	type = "A"
-	ttl = 3600
+  value = "192.168.0.10"
+  name = "terraform"
+  domain = "mydomain.com"
+  type = "A"
+  ttl = 3600
 }
 ```
 
@@ -237,15 +284,15 @@ The following arguments are supported:
 
 The type of record being created affects the interpretation of the `value` argument.
 
-##### A Record
+#### A Record
 
 * `value` is the IPv4 address
 
-##### CNAME Record
+#### CNAME Record
 
 * `value` is the alias name
 
-##### AAAA Record
+#### AAAA Record
 
 * `value` is the IPv6 address
 

--- a/infoblox/helpers.go
+++ b/infoblox/helpers.go
@@ -94,3 +94,13 @@ func validateIPData(d *schema.ResourceData) error {
 	}
 	return nil
 }
+
+func handleReadError(d *schema.ResourceData, recordType string, err error) error {
+	if infobloxErr, ok := err.(infoblox.Error); ok {
+		if infobloxErr.Code() == "Client.Ibap.Data.NotFound" {
+			d.SetId("")
+			return nil
+		}
+	}
+	return fmt.Errorf("Error reading Infoblox %s record: %s", recordType, err)
+}

--- a/infoblox/provider.go
+++ b/infoblox/provider.go
@@ -50,9 +50,9 @@ func Provider() terraform.ResourceProvider {
 			"infoblox_record_cname": infobloxRecordCNAME(),
 			"infoblox_record_ptr":   infobloxRecordPTR(),
 			"infoblox_record_host":  infobloxRecordHost(),
-			// "infoblox_record_txt":   infobloxRecordTXT(),
-			"infoblox_record_mx": infobloxRecordMX(),
-			// "infoblox_record_srv":   infobloxRecordSRV(),
+			"infoblox_record_txt":   infobloxRecordTXT(),
+			"infoblox_record_mx":    infobloxRecordMX(),
+			"infoblox_record_srv":   infobloxRecordSRV(),
 		},
 
 		ConfigureFunc: provideConfigure,

--- a/infoblox/provider.go
+++ b/infoblox/provider.go
@@ -44,6 +44,13 @@ func Provider() terraform.ResourceProvider {
 		ResourcesMap: map[string]*schema.Resource{
 			"infoblox_record": resourceInfobloxRecord(),
 			"infoblox_ip":     resourceInfobloxIP(),
+
+			"infoblox_record_a":     infobloxRecordA(),
+			"infoblox_record_aaaa":  infobloxRecordAAAA(),
+			"infoblox_record_cname": infobloxRecordCNAME(),
+			"infoblox_record_ptr":   infobloxRecordPTR(),
+			// TODO: Write the TXT, SRV, MX, and NS resources.
+			// Requires changes to upstead go-infoblox library.
 		},
 
 		ConfigureFunc: provideConfigure,

--- a/infoblox/provider.go
+++ b/infoblox/provider.go
@@ -49,8 +49,10 @@ func Provider() terraform.ResourceProvider {
 			"infoblox_record_aaaa":  infobloxRecordAAAA(),
 			"infoblox_record_cname": infobloxRecordCNAME(),
 			"infoblox_record_ptr":   infobloxRecordPTR(),
-			// TODO: Write the TXT, SRV, MX, and NS resources.
-			// Requires changes to upstead go-infoblox library.
+			"infoblox_record_host":  infobloxRecordHost(),
+			// "infoblox_record_txt":   infobloxRecordTXT(),
+			"infoblox_record_mx": infobloxRecordMX(),
+			// "infoblox_record_srv":   infobloxRecordSRV(),
 		},
 
 		ConfigureFunc: provideConfigure,

--- a/infoblox/resource_infoblox_record.go
+++ b/infoblox/resource_infoblox_record.go
@@ -44,6 +44,7 @@ func resourceInfobloxRecord() *schema.Resource {
 				Optional: true,
 				Default:  "3600",
 			},
+
 			"view": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
@@ -97,14 +98,14 @@ func resourceInfobloxRecordCreate(d *schema.ResourceData, meta interface{}) erro
 	return resourceInfobloxRecordRead(d, meta)
 }
 
-func handleReadError(d *schema.ResourceData, record_type string, err error) error {
+func handleReadError(d *schema.ResourceData, recordType string, err error) error {
 	if infobloxErr, ok := err.(infoblox.Error); ok {
 		if infobloxErr.Code() == "Client.Ibap.Data.NotFound" {
 			d.SetId("")
 			return nil
 		}
 	}
-	return fmt.Errorf("Error reading Infoblox %s record: %s", record_type, err)
+	return fmt.Errorf("Error reading Infoblox %s record: %s", recordType, err)
 }
 
 func resourceInfobloxRecordRead(d *schema.ResourceData, meta interface{}) error {
@@ -222,7 +223,7 @@ func resourceInfobloxRecordDelete(d *schema.ResourceData, meta interface{}) erro
 
 		deleteErr := client.RecordAObject(d.Id()).Delete(nil)
 		if deleteErr != nil {
-			return fmt.Errorf("Error deleting Infoblox A Record: %s", err)
+			return fmt.Errorf("Error deleting Infoblox A Record: %s", deleteErr)
 		}
 	case "AAAA":
 		_, err := client.GetRecordAAAA(d.Id(), nil)
@@ -232,7 +233,7 @@ func resourceInfobloxRecordDelete(d *schema.ResourceData, meta interface{}) erro
 
 		deleteErr := client.RecordAAAAObject(d.Id()).Delete(nil)
 		if deleteErr != nil {
-			return fmt.Errorf("Error deleting Infoblox AAAA Record: %s", err)
+			return fmt.Errorf("Error deleting Infoblox AAAA Record: %s", deleteErr)
 		}
 	case "CNAME":
 		_, err := client.GetRecordCname(d.Id(), nil)
@@ -242,7 +243,7 @@ func resourceInfobloxRecordDelete(d *schema.ResourceData, meta interface{}) erro
 
 		deleteErr := client.RecordCnameObject(d.Id()).Delete(nil)
 		if deleteErr != nil {
-			return fmt.Errorf("Error deleting Infoblox CNAME Record: %s", err)
+			return fmt.Errorf("Error deleting Infoblox CNAME Record: %s", deleteErr)
 		}
 	default:
 		return fmt.Errorf("resourceInfobloxRecordDelete: unknown type")

--- a/infoblox/resource_infoblox_record.go
+++ b/infoblox/resource_infoblox_record.go
@@ -10,6 +10,10 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
+var deprecated = `The entire 'infoblox_record'
+resource is deprecated and will no longer see active development. It is
+recommended you use the dedicated infoblox_record_* resources instead.`
+
 func resourceInfobloxRecord() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceInfobloxRecordCreate,
@@ -19,9 +23,10 @@ func resourceInfobloxRecord() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"domain": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:       schema.TypeString,
+				Required:   true,
+				ForceNew:   true,
+				Deprecated: deprecated,
 			},
 
 			"name": &schema.Schema{

--- a/infoblox/resource_infoblox_record.go
+++ b/infoblox/resource_infoblox_record.go
@@ -80,12 +80,12 @@ func resourceInfobloxRecordCreate(d *schema.ResourceData, meta interface{}) erro
 		recID, err = client.RecordA().Create(record, opts, nil)
 	case "AAAA":
 		opts := &infoblox.Options{
-			ReturnFields: []string{"ttl", "ipv6addr", "name"},
+			ReturnFields: []string{"ttl", "ipv6addr", "name", "view"},
 		}
 		recID, err = client.RecordAAAA().Create(record, opts, nil)
 	case "CNAME":
 		opts := &infoblox.Options{
-			ReturnFields: []string{"ttl", "canonical", "name"},
+			ReturnFields: []string{"ttl", "canonical", "name", "view"},
 		}
 		recID, err = client.RecordCname().Create(record, opts, nil)
 	default:
@@ -101,16 +101,6 @@ func resourceInfobloxRecordCreate(d *schema.ResourceData, meta interface{}) erro
 	log.Printf("[INFO] record ID: %s", d.Id())
 
 	return resourceInfobloxRecordRead(d, meta)
-}
-
-func handleReadError(d *schema.ResourceData, recordType string, err error) error {
-	if infobloxErr, ok := err.(infoblox.Error); ok {
-		if infobloxErr.Code() == "Client.Ibap.Data.NotFound" {
-			d.SetId("")
-			return nil
-		}
-	}
-	return fmt.Errorf("Error reading Infoblox %s record: %s", recordType, err)
 }
 
 func resourceInfobloxRecordRead(d *schema.ResourceData, meta interface{}) error {
@@ -141,6 +131,7 @@ func resourceInfobloxRecordRead(d *schema.ResourceData, meta interface{}) error 
 		d.Set("name", fqdn[0])
 		d.Set("domain", strings.Join(fqdn[1:], "."))
 		d.Set("ttl", rec.Ttl)
+		d.Set("view", rec.View)
 
 	case "CNAME":
 		rec, err := client.GetRecordCname(d.Id(), nil)
@@ -153,6 +144,7 @@ func resourceInfobloxRecordRead(d *schema.ResourceData, meta interface{}) error 
 		d.Set("name", fqdn[0])
 		d.Set("domain", strings.Join(fqdn[1:], "."))
 		d.Set("ttl", rec.Ttl)
+		d.Set("view", rec.View)
 	default:
 		return fmt.Errorf("resourceInfobloxRecordRead: unknown type")
 	}

--- a/infoblox/resource_infoblox_record_a.go
+++ b/infoblox/resource_infoblox_record_a.go
@@ -1,0 +1,141 @@
+package infoblox
+
+import (
+	"fmt"
+	"log"
+	"net/url"
+
+	infoblox "github.com/fanatic/go-infoblox"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func infobloxRecordA() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceInfobloxARecordCreate,
+		Read:   resourceInfobloxARecordRead,
+		Update: resourceInfobloxARecordUpdate,
+		Delete: resourceInfobloxARecordDelete,
+
+		Schema: map[string]*schema.Schema{
+			// TODO: validate that address is in IPv4 format.
+			"address": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"comment": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
+			"ttl": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"view": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceInfobloxARecordCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*infoblox.Client)
+
+	record := url.Values{}
+	record.Add("ipv4addr", d.Get("address").(string))
+	record.Add("name", d.Get("name").(string))
+	populateSharedAttributes(d, &record)
+
+	log.Printf("[DEBUG] Creating Infoblox A record with configuration: %#v", record)
+
+	opts := &infoblox.Options{
+		ReturnFields: []string{"ipv4addr", "name", "comment", "ttl", "view"},
+	}
+	recordID, err := client.RecordA().Create(record, opts, nil)
+
+	if err != nil {
+		return fmt.Errorf("error creating infoblox A record: %s", err.Error())
+	}
+
+	d.SetId(recordID)
+	log.Printf("[INFO] Infoblox A record created with ID: %s", d.Id())
+
+	return nil
+}
+
+func resourceInfobloxARecordRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*infoblox.Client)
+
+	record, err := client.GetRecordA(d.Id(), nil)
+	if err != nil {
+		return handleReadError(d, "A", err)
+	}
+
+	d.Set("address", record.Ipv4Addr)
+	d.Set("name", record.Name)
+
+	if &record.Comment != nil {
+		d.Set("comment", record.Comment)
+	}
+	if &record.Ttl != nil {
+		d.Set("ttl", record.Ttl)
+	}
+	if &record.View != nil {
+		d.Set("view", record.View)
+	}
+
+	return nil
+}
+
+func resourceInfobloxARecordUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*infoblox.Client)
+
+	_, err := client.GetRecordA(d.Id(), nil)
+	if err != nil {
+		return fmt.Errorf("error finding infoblox A record: %s", err.Error())
+	}
+
+	record := url.Values{}
+	record.Add("ipv4addr", d.Get("address").(string))
+	record.Add("name", d.Get("name").(string))
+	populateSharedAttributes(d, &record)
+
+	log.Printf("[DEBUG] Updating Infoblox A record with configuration: %#v", record)
+
+	opts := &infoblox.Options{
+		ReturnFields: []string{"ipv4addr", "name", "comment", "ttl", "view"},
+	}
+	recordID, err := client.RecordAObject(d.Id()).Update(record, opts, nil)
+	if err != nil {
+		return fmt.Errorf("error updating Infoblox A record: %s", err.Error())
+	}
+
+	d.SetId(recordID)
+	log.Printf("[INFO] Infoblox A record updated with ID: %s", d.Id())
+
+	return resourceInfobloxARecordRead(d, meta)
+}
+
+func resourceInfobloxARecordDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*infoblox.Client)
+
+	log.Printf("[DEBUG] Deleting Infoblox A record: %s, %s", d.Get("name").(string), d.Id())
+	_, err := client.GetRecordA(d.Id(), nil)
+	if err != nil {
+		return fmt.Errorf("error finding Infoblox A record: %s", err.Error())
+	}
+
+	err = client.RecordAObject(d.Id()).Delete(nil)
+	if err != nil {
+		return fmt.Errorf("error deleting Infoblox A record: %s", err.Error())
+	}
+
+	return nil
+}

--- a/infoblox/resource_infoblox_record_aaaa.go
+++ b/infoblox/resource_infoblox_record_aaaa.go
@@ -1,0 +1,141 @@
+package infoblox
+
+import (
+	"fmt"
+	"log"
+	"net/url"
+
+	infoblox "github.com/fanatic/go-infoblox"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func infobloxRecordAAAA() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceInfobloxAAAARecordCreate,
+		Read:   resourceInfobloxAAAARecordRead,
+		Update: resourceInfobloxAAAARecordUpdate,
+		Delete: resourceInfobloxAAAARecordDelete,
+
+		Schema: map[string]*schema.Schema{
+			// TODO: validate that address is in IPv6 format.
+			"address": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"comment": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
+			"ttl": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"view": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceInfobloxAAAARecordCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*infoblox.Client)
+
+	record := url.Values{}
+	record.Add("ipv6addr", d.Get("address").(string))
+	record.Add("name", d.Get("name").(string))
+	populateSharedAttributes(d, &record)
+
+	log.Printf("[DEBUG] Creating Infoblox AAAA record with configuration: %#v", record)
+
+	opts := &infoblox.Options{
+		ReturnFields: []string{"ipv6addr", "name", "comment", "ttl", "view"},
+	}
+	recordID, err := client.RecordAAAA().Create(record, opts, nil)
+
+	if err != nil {
+		return fmt.Errorf("error creating infoblox AAAA record: %s", err.Error())
+	}
+
+	d.SetId(recordID)
+	log.Printf("[INFO] Infoblox AAAA record created with ID: %s", d.Id())
+
+	return nil
+}
+
+func resourceInfobloxAAAARecordRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*infoblox.Client)
+
+	record, err := client.GetRecordAAAA(d.Id(), nil)
+	if err != nil {
+		return handleReadError(d, "AAAA", err)
+	}
+
+	d.Set("address", record.Ipv6Addr)
+	d.Set("name", record.Name)
+
+	if &record.Comment != nil {
+		d.Set("comment", record.Comment)
+	}
+	if &record.Ttl != nil {
+		d.Set("ttl", record.Ttl)
+	}
+	if &record.View != nil {
+		d.Set("view", record.View)
+	}
+
+	return nil
+}
+
+func resourceInfobloxAAAARecordUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*infoblox.Client)
+
+	_, err := client.GetRecordAAAA(d.Id(), nil)
+	if err != nil {
+		return fmt.Errorf("error finding infoblox AAAA record: %s", err.Error())
+	}
+
+	record := url.Values{}
+	record.Add("ipv6addr", d.Get("address").(string))
+	record.Add("name", d.Get("name").(string))
+	populateSharedAttributes(d, &record)
+
+	log.Printf("[DEBUG] Updating Infoblox AAAA record with configuration: %#v", record)
+
+	opts := &infoblox.Options{
+		ReturnFields: []string{"ipv6addr", "name", "comment", "ttl", "view"},
+	}
+	recordID, err := client.RecordAAAAObject(d.Id()).Update(record, opts, nil)
+	if err != nil {
+		return fmt.Errorf("error updating Infoblox AAAA record: %s", err.Error())
+	}
+
+	d.SetId(recordID)
+	log.Printf("[INFO] Infoblox AAAA record updated with ID: %s", d.Id())
+
+	return resourceInfobloxAAAARecordRead(d, meta)
+}
+
+func resourceInfobloxAAAARecordDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*infoblox.Client)
+
+	log.Printf("[DEBUG] Deleting Infoblox AAAA record: %s, %s", d.Get("name").(string), d.Id())
+	_, err := client.GetRecordAAAA(d.Id(), nil)
+	if err != nil {
+		return fmt.Errorf("error finding Infoblox AAAA record: %s", err.Error())
+	}
+
+	err = client.RecordAAAAObject(d.Id()).Delete(nil)
+	if err != nil {
+		return fmt.Errorf("error deleting Infoblox AAAA record: %s", err.Error())
+	}
+
+	return nil
+}

--- a/infoblox/resource_infoblox_record_cname.go
+++ b/infoblox/resource_infoblox_record_cname.go
@@ -1,0 +1,140 @@
+package infoblox
+
+import (
+	"fmt"
+	"log"
+	"net/url"
+
+	infoblox "github.com/fanatic/go-infoblox"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func infobloxRecordCNAME() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceInfobloxCNAMERecordCreate,
+		Read:   resourceInfobloxCNAMERecordRead,
+		Update: resourceInfobloxCNAMERecordUpdate,
+		Delete: resourceInfobloxCNAMERecordDelete,
+
+		Schema: map[string]*schema.Schema{
+			"canonical": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"comment": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
+			"ttl": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"view": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceInfobloxCNAMERecordCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*infoblox.Client)
+
+	record := url.Values{}
+	record.Add("canonical", d.Get("canonical").(string))
+	record.Add("name", d.Get("name").(string))
+	populateSharedAttributes(d, &record)
+
+	log.Printf("[DEBUG] Creating Infoblox CNAME record with configuration: %#v", record)
+
+	opts := &infoblox.Options{
+		ReturnFields: []string{"canonical", "name", "comment", "ttl", "view"},
+	}
+	recordID, err := client.RecordCname().Create(record, opts, nil)
+
+	if err != nil {
+		return fmt.Errorf("error creating infoblox CNAME record: %s", err.Error())
+	}
+
+	d.SetId(recordID)
+	log.Printf("[INFO] Infoblox CNAME record created with ID: %s", d.Id())
+
+	return nil
+}
+
+func resourceInfobloxCNAMERecordRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*infoblox.Client)
+
+	record, err := client.GetRecordCname(d.Id(), nil)
+	if err != nil {
+		return handleReadError(d, "CNAME", err)
+	}
+
+	d.Set("canonical", record.Canonical)
+	d.Set("name", record.Name)
+
+	if &record.Comment != nil {
+		d.Set("comment", record.Comment)
+	}
+	if &record.Ttl != nil {
+		d.Set("ttl", record.Ttl)
+	}
+	if &record.View != nil {
+		d.Set("view", record.View)
+	}
+
+	return nil
+}
+
+func resourceInfobloxCNAMERecordUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*infoblox.Client)
+
+	_, err := client.GetRecordCname(d.Id(), nil)
+	if err != nil {
+		return fmt.Errorf("error finding infoblox CNAME record: %s", err.Error())
+	}
+
+	record := url.Values{}
+	record.Add("canonical", d.Get("canonical").(string))
+	record.Add("name", d.Get("name").(string))
+	populateSharedAttributes(d, &record)
+
+	log.Printf("[DEBUG] Updating Infoblox CNAME record with configuration: %#v", record)
+
+	opts := &infoblox.Options{
+		ReturnFields: []string{"canonical", "name", "comment", "ttl", "view"},
+	}
+	recordID, err := client.RecordCnameObject(d.Id()).Update(record, opts, nil)
+	if err != nil {
+		return fmt.Errorf("error updating Infoblox CNAME record: %s", err.Error())
+	}
+
+	d.SetId(recordID)
+	log.Printf("[INFO] Infoblox CNAME record updated with ID: %s", d.Id())
+
+	return resourceInfobloxCNAMERecordRead(d, meta)
+}
+
+func resourceInfobloxCNAMERecordDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*infoblox.Client)
+
+	log.Printf("[DEBUG] Deleting Infoblox CNAME record: %s, %s", d.Get("name").(string), d.Id())
+	_, err := client.GetRecordCname(d.Id(), nil)
+	if err != nil {
+		return fmt.Errorf("error finding Infoblox CNAME record: %s", err.Error())
+	}
+
+	err = client.RecordCnameObject(d.Id()).Delete(nil)
+	if err != nil {
+		return fmt.Errorf("error deleting Infoblox CNAME record: %s", err.Error())
+	}
+
+	return nil
+}

--- a/infoblox/resource_infoblox_record_host.go
+++ b/infoblox/resource_infoblox_record_host.go
@@ -1,0 +1,302 @@
+package infoblox
+
+import (
+	"fmt"
+	"log"
+	"net/url"
+
+	infoblox "github.com/fanatic/go-infoblox"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// hostIPv4Schema represents the schema for the host IPv4 sub-resource
+func hostIPv4Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"address": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
+		"configure_for_dhcp": {
+			Type:     schema.TypeBool,
+			Optional: true,
+		},
+		"host": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"mac": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+	}
+}
+
+// hostIPv6Schema represents the schema for the host IPv4 sub-resource
+func hostIPv6Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"address": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
+		"configure_for_dhcp": {
+			Type:     schema.TypeBool,
+			Optional: true,
+		},
+		"host": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"mac": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+	}
+}
+
+func infobloxRecordHost() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceInfobloxHostRecordCreate,
+		Read:   resourceInfobloxHostRecordRead,
+		Update: resourceInfobloxHostRecordUpdate,
+		Delete: resourceInfobloxHostRecordDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"ipv4addr": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Resource{Schema: hostIPv4Schema()},
+			},
+			"ipv6addr": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Resource{Schema: hostIPv6Schema()},
+			},
+			"configure_for_dns": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"comment": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
+			"ttl": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"view": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func ipv4sFromList(ipv4s []interface{}) []infoblox.HostIpv4Addr {
+	result := make([]infoblox.HostIpv4Addr, 0, len(ipv4s))
+	for _, v := range ipv4s {
+		ipMap := v.(map[string]interface{})
+		i := infoblox.HostIpv4Addr{}
+
+		i.Ipv4Addr = ipMap["address"].(string)
+
+		if val, ok := ipMap["configure_for_dhcp"]; ok {
+			i.ConfigureForDHCP = val.(bool)
+		}
+		if val, ok := ipMap["host"]; ok {
+			i.Host = val.(string)
+		}
+		if val, ok := ipMap["mac"]; ok {
+			i.MAC = val.(string)
+		}
+
+		result = append(result, i)
+	}
+	return result
+}
+
+func ipv6sFromList(ipv6s []interface{}) []infoblox.HostIpv6Addr {
+	result := make([]infoblox.HostIpv6Addr, 0, len(ipv6s))
+	for _, v := range ipv6s {
+		ip := v.(*schema.ResourceData)
+		i := infoblox.HostIpv6Addr{}
+
+		if attr, ok := ip.GetOk("address"); ok {
+			i.Ipv6Addr = attr.(string)
+		}
+		if attr, ok := ip.GetOk("configure_for_dhcp"); ok {
+			i.ConfigureForDHCP = attr.(bool)
+		}
+		if attr, ok := ip.GetOk("host"); ok {
+			i.Host = attr.(string)
+		}
+		if attr, ok := ip.GetOk("mac"); ok {
+			i.MAC = attr.(string)
+		}
+		result = append(result, i)
+	}
+	return result
+}
+
+func hostObjectFromAttributes(d *schema.ResourceData) infoblox.RecordHostObject {
+	hostObject := infoblox.RecordHostObject{}
+
+	if attr, ok := d.GetOk("name"); ok {
+		hostObject.Name = attr.(string)
+	}
+	if attr, ok := d.GetOk("configure_for_dns"); ok {
+		hostObject.ConfigureForDNS = attr.(bool)
+	}
+	if attr, ok := d.GetOk("comment"); ok {
+		hostObject.Comment = attr.(string)
+	}
+	if attr, ok := d.GetOk("ttl"); ok {
+		hostObject.Ttl = attr.(int)
+	}
+	if attr, ok := d.GetOk("view"); ok {
+		hostObject.View = attr.(string)
+	}
+	if attr, ok := d.GetOk("ipv4addr"); ok {
+		hostObject.Ipv4Addrs = ipv4sFromList(attr.([]interface{}))
+	}
+	if attr, ok := d.GetOk("ipv6addr"); ok {
+		hostObject.Ipv6Addrs = ipv6sFromList(attr.([]interface{}))
+	}
+
+	return hostObject
+}
+
+func resourceInfobloxHostRecordCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*infoblox.Client)
+
+	record := url.Values{}
+	hostObject := hostObjectFromAttributes(d)
+
+	log.Printf("[DEBUG] Creating Infoblox Host record with configuration: %#v", hostObject)
+	opts := &infoblox.Options{
+		ReturnFields: []string{"name", "ipv4addr", "ipv6addr", "configure_for_dns", "comment", "ttl", "view"},
+	}
+	recordID, err := client.RecordHost().Create(record, opts, hostObject)
+	if err != nil {
+		return fmt.Errorf("error creating infoblox Host record: %s", err.Error())
+	}
+
+	d.SetId(recordID)
+	log.Printf("[INFO] Infoblox Host record created with ID: %s", d.Id())
+	return nil
+}
+
+func resourceInfobloxHostRecordRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*infoblox.Client)
+
+	record, err := client.GetRecordHost(d.Id(), nil)
+	if err != nil {
+		return handleReadError(d, "Host", err)
+	}
+
+	d.Set("name", record.Name)
+	if &record.ConfigureForDNS != nil {
+		d.Set("configure_for_dns", record.ConfigureForDNS)
+	}
+	if &record.Comment != nil {
+		d.Set("comment", record.Comment)
+	}
+	if &record.Ttl != nil {
+		d.Set("ttl", record.Ttl)
+	}
+	if &record.View != nil {
+		d.Set("view", record.View)
+	}
+	if &record.Ipv4Addrs != nil {
+		result := make([]map[string]interface{}, 1)
+		for _, v := range record.Ipv4Addrs {
+			i := make(map[string]interface{})
+
+			i["address"] = v.Ipv4Addr
+			if &v.ConfigureForDHCP != nil {
+				i["configure_for_dhcp"] = v.ConfigureForDHCP
+			}
+			if &v.Host != nil {
+				i["host"] = v.Host
+			}
+			if &v.MAC != nil {
+				i["mac"] = v.MAC
+			}
+
+			result = append(result, i)
+		}
+		d.Set("ipv4addr", result)
+	}
+	if &record.Ipv6Addrs != nil {
+		result := make([]map[string]interface{}, 1)
+		for _, v := range record.Ipv6Addrs {
+			i := make(map[string]interface{})
+
+			i["address"] = v.Ipv6Addr
+			if &v.ConfigureForDHCP != nil {
+				i["configure_for_dhcp"] = v.ConfigureForDHCP
+			}
+			if &v.Host != nil {
+				i["host"] = v.Host
+			}
+			if &v.MAC != nil {
+				i["mac"] = v.MAC
+			}
+
+			result = append(result, i)
+		}
+		d.Set("ipv6addr", result)
+	}
+
+	return nil
+}
+
+func resourceInfobloxHostRecordUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*infoblox.Client)
+
+	_, err := client.GetRecordHost(d.Id(), nil)
+	if err != nil {
+		return fmt.Errorf("error finding infoblox Host record: %s", err.Error())
+	}
+
+	record := url.Values{}
+	hostObject := hostObjectFromAttributes(d)
+
+	log.Printf("[DEBUG] Updating Infoblox Host record with configuration: %#v", hostObject)
+
+	opts := &infoblox.Options{
+		ReturnFields: []string{"name", "ipv4addr", "ipv6addr", "configure_for_dns", "comment", "ttl", "view"},
+	}
+	recordID, err := client.RecordHostObject(d.Id()).Update(record, opts, hostObject)
+	if err != nil {
+		return fmt.Errorf("error updating Infoblox Host record: %s", err.Error())
+	}
+
+	d.SetId(recordID)
+	log.Printf("[INFO] Infoblox Host record updated with ID: %s", d.Id())
+
+	return resourceInfobloxHostRecordRead(d, meta)
+}
+
+func resourceInfobloxHostRecordDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*infoblox.Client)
+
+	log.Printf("[DEBUG] Deleting Infoblox Host record: %s, %s", d.Get("name").(string), d.Id())
+	_, err := client.GetRecordHost(d.Id(), nil)
+	if err != nil {
+		return fmt.Errorf("error finding Infoblox Host record: %s", err.Error())
+	}
+
+	err = client.RecordHostObject(d.Id()).Delete(nil)
+	if err != nil {
+		return fmt.Errorf("error deleting Infoblox Host record: %s", err.Error())
+	}
+
+	return nil
+}

--- a/infoblox/resource_infoblox_record_mx.go
+++ b/infoblox/resource_infoblox_record_mx.go
@@ -1,0 +1,151 @@
+package infoblox
+
+import (
+	"fmt"
+	"log"
+	"net/url"
+	"strconv"
+
+	infoblox "github.com/fanatic/go-infoblox"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func infobloxRecordMX() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceInfobloxMXRecordCreate,
+		Read:   resourceInfobloxMXRecordRead,
+		Update: resourceInfobloxMXRecordUpdate,
+		Delete: resourceInfobloxMXRecordDelete,
+
+		Schema: map[string]*schema.Schema{
+			"exchanger": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"pref": &schema.Schema{
+				Type:     schema.TypeInt,
+				Required: true,
+				ForceNew: false,
+			},
+			"comment": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
+			"ttl": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"view": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceInfobloxMXRecordCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*infoblox.Client)
+
+	record := url.Values{}
+	record.Add("exchanger", d.Get("exchanger").(string))
+	record.Add("name", d.Get("name").(string))
+	record.Add("pref", strconv.Itoa(d.Get("pref").(int)))
+	populateSharedAttributes(d, &record)
+
+	log.Printf("[DEBUG] Creating Infoblox MX record with configuration: %#v", record)
+
+	opts := &infoblox.Options{
+		ReturnFields: []string{"exchanger", "name", "pref", "comment", "ttl", "view"},
+	}
+
+	// TODO: Add MX support to go-infoblox
+	recordID, err := client.RecordMx().Create(record, opts, nil)
+
+	if err != nil {
+		return fmt.Errorf("error creating infoblox MX record: %s", err.Error())
+	}
+
+	d.SetId(recordID)
+	log.Printf("[INFO] Infoblox MX record created with ID: %s", d.Id())
+
+	return nil
+}
+
+func resourceInfobloxMXRecordRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*infoblox.Client)
+
+	record, err := client.GetRecordMx(d.Id(), nil)
+	if err != nil {
+		return handleReadError(d, "MX", err)
+	}
+
+	d.Set("exchanger", record.Exchanger)
+	d.Set("name", record.Name)
+	d.Set("pref", record.Pref)
+
+	if &record.Comment != nil {
+		d.Set("comment", record.Comment)
+	}
+	if &record.Ttl != nil {
+		d.Set("ttl", record.Ttl)
+	}
+	if &record.View != nil {
+		d.Set("view", record.View)
+	}
+
+	return nil
+}
+
+func resourceInfobloxMXRecordUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*infoblox.Client)
+
+	_, err := client.GetRecordMx(d.Id(), nil)
+	if err != nil {
+		return fmt.Errorf("error finding infoblox MX record: %s", err.Error())
+	}
+
+	record := url.Values{}
+	record.Add("exchanger", d.Get("address").(string))
+	record.Add("name", d.Get("name").(string))
+	record.Add("pref", strconv.Itoa(d.Get("pref").(int)))
+	populateSharedAttributes(d, &record)
+
+	log.Printf("[DEBUG] Updating Infoblox MX record with configuration: %#v", record)
+
+	opts := &infoblox.Options{
+		ReturnFields: []string{"exchanger", "name", "pref", "comment", "ttl", "view"},
+	}
+	recordID, err := client.RecordMxObject(d.Id()).Update(record, opts, nil)
+	if err != nil {
+		return fmt.Errorf("error updating Infoblox MX record: %s", err.Error())
+	}
+
+	d.SetId(recordID)
+	log.Printf("[INFO] Infoblox MX record updated with ID: %s", d.Id())
+
+	return resourceInfobloxMXRecordRead(d, meta)
+}
+
+func resourceInfobloxMXRecordDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*infoblox.Client)
+
+	log.Printf("[DEBUG] Deleting Infoblox MX record: %s, %s", d.Get("name").(string), d.Id())
+	_, err := client.GetRecordMx(d.Id(), nil)
+	if err != nil {
+		return fmt.Errorf("error finding Infoblox MX record: %s", err.Error())
+	}
+
+	err = client.RecordMxObject(d.Id()).Delete(nil)
+	if err != nil {
+		return fmt.Errorf("error deleting Infoblox MX record: %s", err.Error())
+	}
+
+	return nil
+}

--- a/infoblox/resource_infoblox_record_ptr.go
+++ b/infoblox/resource_infoblox_record_ptr.go
@@ -1,0 +1,204 @@
+package infoblox
+
+import (
+	"fmt"
+	"log"
+	"net/url"
+
+	infoblox "github.com/fanatic/go-infoblox"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func infobloxRecordPTR() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceInfobloxPTRRecordCreate,
+		Read:   resourceInfobloxPTRRecordRead,
+		Update: resourceInfobloxPTRRecordUpdate,
+		Delete: resourceInfobloxPTRRecordDelete,
+
+		Schema: map[string]*schema.Schema{
+			"address": &schema.Schema{
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name"},
+			},
+			"ptrdname": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": &schema.Schema{
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"address"},
+			},
+			"comment": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
+			"ttl": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"view": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceInfobloxPTRRecordCreate(d *schema.ResourceData, meta interface{}) error {
+	err := validatePTRFields(d)
+	if err != nil {
+		return err
+	}
+
+	client := meta.(*infoblox.Client)
+	record := url.Values{}
+
+	if attr, ok := d.GetOk("address"); ok {
+		addressType, err := ipType(attr.(string))
+		if err != nil {
+			return err
+		}
+		record.Add(addressType, attr.(string))
+	} else {
+		record.Add("name", d.Get("name").(string))
+	}
+	record.Add("ptrdname", d.Get("ptrdname").(string))
+	populateSharedAttributes(d, &record)
+
+	log.Printf("[DEBUG] Creating Infoblox PTR record with configuration: %#v", record)
+
+	opts := ptrOpts(d)
+	recordID, err := client.RecordPtr().Create(record, opts, nil)
+
+	if err != nil {
+		return fmt.Errorf("error creating infoblox PTR record: %s", err.Error())
+	}
+
+	d.SetId(recordID)
+	log.Printf("[INFO] Infoblox PTR record created with ID: %s", d.Id())
+
+	return nil
+}
+
+func resourceInfobloxPTRRecordRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*infoblox.Client)
+
+	record, err := client.GetRecordPtr(d.Id(), nil)
+	if err != nil {
+		return handleReadError(d, "PTR", err)
+	}
+
+	d.Set("ptrdname", record.PtrDname)
+
+	if &record.Ipv4Addr != nil {
+		d.Set("address", record.Ipv4Addr)
+	}
+	if &record.Ipv6Addr != nil {
+		d.Set("address", record.Ipv6Addr)
+	}
+	if &record.Name != nil {
+		d.Set("name", record.Name)
+	}
+	if &record.Comment != nil {
+		d.Set("comment", record.Comment)
+	}
+	if &record.Ttl != nil {
+		d.Set("ttl", record.Ttl)
+	}
+	if &record.View != nil {
+		d.Set("view", record.View)
+	}
+
+	return nil
+}
+
+func resourceInfobloxPTRRecordUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*infoblox.Client)
+	record := url.Values{}
+
+	_, err := client.GetRecordPtr(d.Id(), nil)
+	if err != nil {
+		return fmt.Errorf("error finding infoblox PTR record: %s", err.Error())
+	}
+
+	if attr, ok := d.GetOk("address"); ok {
+		addressType, err := ipType(attr.(string))
+		if err != nil {
+			return err
+		}
+		record.Add(addressType, attr.(string))
+	} else {
+		record.Add("name", d.Get("name").(string))
+	}
+	record.Add("ptrdname", d.Get("ptrdname").(string))
+	populateSharedAttributes(d, &record)
+
+	log.Printf("[DEBUG] Updating Infoblox PTR record with configuration: %#v", record)
+
+	opts := ptrOpts(d)
+	recordID, err := client.RecordPtrObject(d.Id()).Update(record, opts, nil)
+	if err != nil {
+		return fmt.Errorf("error updating Infoblox PTR record: %s", err.Error())
+	}
+
+	d.SetId(recordID)
+	log.Printf("[INFO] Infoblox PTR record updated with ID: %s", d.Id())
+
+	return resourceInfobloxPTRRecordRead(d, meta)
+}
+
+func resourceInfobloxPTRRecordDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*infoblox.Client)
+
+	log.Printf("[DEBUG] Deleting Infoblox PTR record: %s, %s", d.Get("ptrdname").(string), d.Id())
+	_, err := client.GetRecordPtr(d.Id(), nil)
+	if err != nil {
+		return fmt.Errorf("error finding Infoblox PTR record: %s", err.Error())
+	}
+
+	err = client.RecordPtrObject(d.Id()).Delete(nil)
+	if err != nil {
+		return fmt.Errorf("error deleting Infoblox PTR record: %s", err.Error())
+	}
+
+	return nil
+}
+
+// Returns an error if neither address and name are set or if both are set
+func validatePTRFields(d *schema.ResourceData) error {
+	_, hasAddress := d.GetOk("address")
+	_, hasName := d.GetOk("name")
+	if hasAddress && hasName {
+		return fmt.Errorf("you must specify name or address for PTR record, not both")
+	}
+	if !(hasAddress || hasName) {
+		return fmt.Errorf("you must specify a name of an address for PTR record")
+	}
+
+	return nil
+}
+
+// A PTR object can have either an ipv4/ipv6 address or a name, so when
+// constructing our ReturnFields slice we read the Schema to see which we want
+// to return.
+func ptrOpts(d *schema.ResourceData) *infoblox.Options {
+	opts := []string{"ptrdname", "ttl", "comment", "view"}
+
+	if _, ok := d.GetOk("name"); ok {
+		opts = append(opts, "name")
+	}
+	if _, ok := d.GetOk("ipv4addr"); ok {
+		opts = append(opts, "ipv4addr")
+	}
+	if _, ok := d.GetOk("ipv6addr"); ok {
+		opts = append(opts, "ipv6addr")
+	}
+
+	return &infoblox.Options{ReturnFields: opts}
+}

--- a/infoblox/resource_infoblox_record_srv.go
+++ b/infoblox/resource_infoblox_record_srv.go
@@ -1,0 +1,173 @@
+package infoblox
+
+import (
+	"fmt"
+	"log"
+	"net/url"
+	"strconv"
+
+	infoblox "github.com/fanatic/go-infoblox"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func infobloxRecordSRV() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceInfobloxSRVRecordCreate,
+		Read:   resourceInfobloxSRVRecordRead,
+		Update: resourceInfobloxSRVRecordUpdate,
+		Delete: resourceInfobloxSRVRecordDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"port": &schema.Schema{
+				Type:     schema.TypeInt,
+				Required: true,
+				ForceNew: false,
+			},
+			"priority": &schema.Schema{
+				Type:     schema.TypeInt,
+				Required: true,
+				ForceNew: false,
+			},
+			"target": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
+			"weight": &schema.Schema{
+				Type:     schema.TypeInt,
+				Required: true,
+				ForceNew: false,
+			},
+			"comment": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
+			"ttl": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"view": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceInfobloxSRVRecordCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*infoblox.Client)
+
+	record := url.Values{}
+	record.Add("name", d.Get("name").(string))
+	record.Add("port", strconv.Itoa(d.Get("port").(int)))
+	record.Add("priority", strconv.Itoa(d.Get("priority").(int)))
+	record.Add("target", d.Get("target").(string))
+	record.Add("weight", strconv.Itoa(d.Get("weight").(int)))
+	populateSharedAttributes(d, &record)
+
+	log.Printf("[DEBUG] Creating Infoblox SRV record with configuration: %#v", record)
+
+	opts := &infoblox.Options{
+		ReturnFields: []string{"name", "port", "priority", "target", "weight", "comment", "ttl", "view"},
+	}
+
+	// TODO: Add SRV support to go-infoblox
+	recordID, err := client.RecordSrv().Create(record, opts, nil)
+
+	if err != nil {
+		return fmt.Errorf("error creating infoblox SRV record: %s", err.Error())
+	}
+
+	d.SetId(recordID)
+	log.Printf("[INFO] Infoblox SRV record created with ID: %s", d.Id())
+
+	return nil
+}
+
+func resourceInfobloxSRVRecordRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*infoblox.Client)
+
+	record, err := client.GetRecordSrv(d.Id(), nil)
+	if err != nil {
+		return handleReadError(d, "SRV", err)
+	}
+
+	d.Set("name", record.Name)
+	d.Set("port", record.Port)
+	d.Set("priority", record.Priority)
+	d.Set("target", record.Target)
+	d.Set("weight", record.Weight)
+
+	if &record.Comment != nil {
+		d.Set("comment", record.Comment)
+	}
+	if &record.Ttl != nil {
+		d.Set("ttl", record.Ttl)
+	}
+	if &record.View != nil {
+		d.Set("view", record.View)
+	}
+
+	return nil
+}
+
+func resourceInfobloxSRVRecordUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*infoblox.Client)
+
+	_, err := client.GetRecordSrv(d.Id(), nil)
+	if err != nil {
+		return fmt.Errorf("error finding infoblox SRV record: %s", err.Error())
+	}
+
+	record := url.Values{}
+	// name string
+	// port int
+	// priority int
+	// target fqdn/string
+	// weight int
+	// shared
+	record.Add("name", d.Get("name").(string))
+	record.Add("port", strconv.Itoa(d.Get("port").(int)))
+	record.Add("priority", strconv.Itoa(d.Get("priority").(int)))
+	record.Add("target", d.Get("target").(string))
+	record.Add("weight", strconv.Itoa(d.Get("weight").(int)))
+	populateSharedAttributes(d, &record)
+
+	log.Printf("[DEBUG] Updating Infoblox SRV record with configuration: %#v", record)
+
+	opts := &infoblox.Options{
+		ReturnFields: []string{"name", "port", "priority", "target", "weight", "comment", "ttl", "view"},
+	}
+	recordID, err := client.RecordSrvObject(d.Id()).Update(record, opts, nil)
+	if err != nil {
+		return fmt.Errorf("error updating Infoblox SRV record: %s", err.Error())
+	}
+
+	d.SetId(recordID)
+	log.Printf("[INFO] Infoblox SRV record updated with ID: %s", d.Id())
+
+	return resourceInfobloxSRVRecordRead(d, meta)
+}
+
+func resourceInfobloxSRVRecordDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*infoblox.Client)
+
+	log.Printf("[DEBUG] Deleting Infoblox SRV record: %s, %s", d.Get("name").(string), d.Id())
+	_, err := client.GetRecordSrv(d.Id(), nil)
+	if err != nil {
+		return fmt.Errorf("error finding Infoblox SRV record: %s", err.Error())
+	}
+
+	err = client.RecordSrvObject(d.Id()).Delete(nil)
+	if err != nil {
+		return fmt.Errorf("error deleting Infoblox SRV record: %s", err.Error())
+	}
+
+	return nil
+}

--- a/infoblox/resource_infoblox_record_txt.go
+++ b/infoblox/resource_infoblox_record_txt.go
@@ -1,0 +1,141 @@
+package infoblox
+
+import (
+	"fmt"
+	"log"
+	"net/url"
+
+	infoblox "github.com/fanatic/go-infoblox"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func infobloxRecordTXT() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceInfobloxTXTRecordCreate,
+		Read:   resourceInfobloxTXTRecordRead,
+		Update: resourceInfobloxTXTRecordUpdate,
+		Delete: resourceInfobloxTXTRecordDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"text": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: false,
+			},
+			"comment": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
+			"ttl": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"view": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceInfobloxTXTRecordCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*infoblox.Client)
+
+	record := url.Values{}
+	record.Add("name", d.Get("name").(string))
+	record.Add("text", d.Get("text").(string))
+	populateSharedAttributes(d, &record)
+
+	log.Printf("[DEBUG] Creating Infoblox TXT record with configuration: %#v", record)
+
+	opts := &infoblox.Options{
+		ReturnFields: []string{"name", "text", "comment", "ttl", "view"},
+	}
+
+	recordID, err := client.RecordTxt().Create(record, opts, nil)
+
+	if err != nil {
+		return fmt.Errorf("error creating infoblox TXT record: %s", err.Error())
+	}
+
+	d.SetId(recordID)
+	log.Printf("[INFO] Infoblox TXT record created with ID: %s", d.Id())
+
+	return nil
+}
+
+func resourceInfobloxTXTRecordRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*infoblox.Client)
+
+	record, err := client.GetRecordTxt(d.Id(), nil)
+	if err != nil {
+		return handleReadError(d, "TXT", err)
+	}
+
+	d.Set("name", record.Name)
+	d.Set("text", record.Text)
+
+	if &record.Comment != nil {
+		d.Set("comment", record.Comment)
+	}
+	if &record.Ttl != nil {
+		d.Set("ttl", record.Ttl)
+	}
+	if &record.View != nil {
+		d.Set("view", record.View)
+	}
+
+	return nil
+}
+
+func resourceInfobloxTXTRecordUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*infoblox.Client)
+
+	_, err := client.GetRecordTxt(d.Id(), nil)
+	if err != nil {
+		return fmt.Errorf("error finding infoblox TXT record: %s", err.Error())
+	}
+
+	record := url.Values{}
+	record.Add("name", d.Get("name").(string))
+	record.Add("text", d.Get("text").(string))
+	populateSharedAttributes(d, &record)
+
+	log.Printf("[DEBUG] Updating Infoblox TXT record with configuration: %#v", record)
+
+	opts := &infoblox.Options{
+		ReturnFields: []string{"name", "text", "comment", "ttl", "view"},
+	}
+	recordID, err := client.RecordTxtObject(d.Id()).Update(record, opts, nil)
+	if err != nil {
+		return fmt.Errorf("error updating Infoblox TXT record: %s", err.Error())
+	}
+
+	d.SetId(recordID)
+	log.Printf("[INFO] Infoblox TXT record updated with ID: %s", d.Id())
+
+	return resourceInfobloxTXTRecordRead(d, meta)
+}
+
+func resourceInfobloxTXTRecordDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*infoblox.Client)
+
+	log.Printf("[DEBUG] Deleting Infoblox TXT record: %s, %s", d.Get("name").(string), d.Id())
+	_, err := client.GetRecordTxt(d.Id(), nil)
+	if err != nil {
+		return fmt.Errorf("error finding Infoblox TXT record: %s", err.Error())
+	}
+
+	err = client.RecordTxtObject(d.Id()).Delete(nil)
+	if err != nil {
+		return fmt.Errorf("error deleting Infoblox TXT record: %s", err.Error())
+	}
+
+	return nil
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -198,10 +198,10 @@
 			"revisionTime": "2017-07-11T18:34:51Z"
 		},
 		{
-			"checksumSHA1": "5bsYJYb0J8qVLnHwtPWCFUTmSo4=",
+			"checksumSHA1": "h8AiJc65HX3Vp1vGkOBEA5umorQ=",
 			"path": "github.com/fanatic/go-infoblox",
-			"revision": "81fb1b02c381047011f80483457dee9de5d105fa",
-			"revisionTime": "2017-03-25T00:40:47Z"
+			"revision": "ece4e23a370d0bbac46d17f386f73d0d124a8d97",
+			"revisionTime": "2018-04-14T18:49:06Z"
 		},
 		{
 			"checksumSHA1": "87LEfpY9cOk9CP7pWyIbmQ/6enU=",


### PR DESCRIPTION
This pull request creates new resources for infoblox record types, and moves away from the `infoblox_record` resource which is brittle and hard to extend.

Specifically resources have been created for `A`, `AAAA`, `CNAME`, `PTR`, `MX`. `SRV`, `TXT`, and `Host` records. More justification can be found in [38a29cc](https://github.com/prudhvitella/terraform-provider-infoblox/commit/38a29ccd4ad33ab0e53452f959eb996771d9e067).

Additionally, a few things were cleaned up a little, and some fields were added to the current records.