### PR TITLE
Request all fields from infoblox API when reading records

### DIFF
--- a/infoblox/resource_infoblox_record_a.go
+++ b/infoblox/resource_infoblox_record_a.go
@@ -83,7 +83,6 @@ func resourceInfobloxARecordCreate(d *schema.ResourceData, meta interface{}) err
 	opts := &infoblox.Options{
 		ReturnFields: []string{"ipv4addr", "name", "comment", "ttl", "view"},
 	}
-
 	recordID, err := client.RecordA().Create(record, opts, aRecordObject)
 	if err != nil {
 		return fmt.Errorf("error creating infoblox A record: %s", err.Error())
@@ -101,7 +100,6 @@ func resourceInfobloxARecordRead(d *schema.ResourceData, meta interface{}) error
 	opts := &infoblox.Options{
 		ReturnFields: []string{"ipv4addr", "name", "comment", "ttl", "view"},
 	}
-
 	record, err := client.GetRecordA(d.Id(), opts)
 	if err != nil {
 		return handleReadError(d, "A", err)
@@ -119,7 +117,10 @@ func resourceInfobloxARecordRead(d *schema.ResourceData, meta interface{}) error
 func resourceInfobloxARecordUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*infoblox.Client)
 
-	_, err := client.GetRecordA(d.Id(), nil)
+	opts := &infoblox.Options{
+		ReturnFields: []string{"ipv4addr", "name", "comment", "ttl", "view"},
+	}
+	_, err := client.GetRecordA(d.Id(), opts)
 	if err != nil {
 		return fmt.Errorf("error finding infoblox A record: %s", err.Error())
 	}
@@ -129,9 +130,6 @@ func resourceInfobloxARecordUpdate(d *schema.ResourceData, meta interface{}) err
 
 	log.Printf("[DEBUG] Updating Infoblox A record with configuration: %#v", record)
 
-	opts := &infoblox.Options{
-		ReturnFields: []string{"ipv4addr", "name", "comment", "ttl", "view"},
-	}
 	recordID, err := client.RecordAObject(d.Id()).Update(record, opts, aRecordObject)
 	if err != nil {
 		return fmt.Errorf("error updating Infoblox A record: %s", err.Error())

--- a/infoblox/resource_infoblox_record_aaaa.go
+++ b/infoblox/resource_infoblox_record_aaaa.go
@@ -73,7 +73,10 @@ func resourceInfobloxAAAARecordCreate(d *schema.ResourceData, meta interface{}) 
 func resourceInfobloxAAAARecordRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*infoblox.Client)
 
-	record, err := client.GetRecordAAAA(d.Id(), nil)
+	opts := &infoblox.Options{
+		ReturnFields: []string{"ipv6addr", "name", "comment", "ttl", "view"},
+	}
+	record, err := client.GetRecordAAAA(d.Id(), opts)
 	if err != nil {
 		return handleReadError(d, "AAAA", err)
 	}
@@ -97,7 +100,10 @@ func resourceInfobloxAAAARecordRead(d *schema.ResourceData, meta interface{}) er
 func resourceInfobloxAAAARecordUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*infoblox.Client)
 
-	_, err := client.GetRecordAAAA(d.Id(), nil)
+	opts := &infoblox.Options{
+		ReturnFields: []string{"ipv6addr", "name", "comment", "ttl", "view"},
+	}
+	_, err := client.GetRecordAAAA(d.Id(), opts)
 	if err != nil {
 		return fmt.Errorf("error finding infoblox AAAA record: %s", err.Error())
 	}
@@ -109,9 +115,6 @@ func resourceInfobloxAAAARecordUpdate(d *schema.ResourceData, meta interface{}) 
 
 	log.Printf("[DEBUG] Updating Infoblox AAAA record with configuration: %#v", record)
 
-	opts := &infoblox.Options{
-		ReturnFields: []string{"ipv6addr", "name", "comment", "ttl", "view"},
-	}
 	recordID, err := client.RecordAAAAObject(d.Id()).Update(record, opts, nil)
 	if err != nil {
 		return fmt.Errorf("error updating Infoblox AAAA record: %s", err.Error())

--- a/infoblox/resource_infoblox_record_cname.go
+++ b/infoblox/resource_infoblox_record_cname.go
@@ -58,7 +58,6 @@ func resourceInfobloxCNAMERecordCreate(d *schema.ResourceData, meta interface{})
 		ReturnFields: []string{"canonical", "name", "comment", "ttl", "view"},
 	}
 	recordID, err := client.RecordCname().Create(record, opts, nil)
-
 	if err != nil {
 		return fmt.Errorf("error creating infoblox CNAME record: %s", err.Error())
 	}
@@ -72,7 +71,10 @@ func resourceInfobloxCNAMERecordCreate(d *schema.ResourceData, meta interface{})
 func resourceInfobloxCNAMERecordRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*infoblox.Client)
 
-	record, err := client.GetRecordCname(d.Id(), nil)
+	opts := &infoblox.Options{
+		ReturnFields: []string{"canonical", "name", "comment", "ttl", "view"},
+	}
+	record, err := client.GetRecordCname(d.Id(), opts)
 	if err != nil {
 		return handleReadError(d, "CNAME", err)
 	}
@@ -96,7 +98,10 @@ func resourceInfobloxCNAMERecordRead(d *schema.ResourceData, meta interface{}) e
 func resourceInfobloxCNAMERecordUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*infoblox.Client)
 
-	_, err := client.GetRecordCname(d.Id(), nil)
+	opts := &infoblox.Options{
+		ReturnFields: []string{"canonical", "name", "comment", "ttl", "view"},
+	}
+	_, err := client.GetRecordCname(d.Id(), opts)
 	if err != nil {
 		return fmt.Errorf("error finding infoblox CNAME record: %s", err.Error())
 	}
@@ -108,9 +113,6 @@ func resourceInfobloxCNAMERecordUpdate(d *schema.ResourceData, meta interface{})
 
 	log.Printf("[DEBUG] Updating Infoblox CNAME record with configuration: %#v", record)
 
-	opts := &infoblox.Options{
-		ReturnFields: []string{"canonical", "name", "comment", "ttl", "view"},
-	}
 	recordID, err := client.RecordCnameObject(d.Id()).Update(record, opts, nil)
 	if err != nil {
 		return fmt.Errorf("error updating Infoblox CNAME record: %s", err.Error())

--- a/infoblox/resource_infoblox_record_host.go
+++ b/infoblox/resource_infoblox_record_host.go
@@ -184,7 +184,7 @@ func resourceInfobloxHostRecordCreate(d *schema.ResourceData, meta interface{}) 
 func resourceInfobloxHostRecordRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*infoblox.Client)
 
-	record, err := client.GetRecordHost(d.Id(), nil)
+	record, err := client.GetRecordHost(d.Id(), &infoblox.Options{ReturnBasicFields: true, ReturnFields: []string {"configure_for_dns"}})
 	if err != nil {
 		return handleReadError(d, "Host", err)
 	}

--- a/infoblox/resource_infoblox_record_host.go
+++ b/infoblox/resource_infoblox_record_host.go
@@ -184,7 +184,10 @@ func resourceInfobloxHostRecordCreate(d *schema.ResourceData, meta interface{}) 
 func resourceInfobloxHostRecordRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*infoblox.Client)
 
-	record, err := client.GetRecordHost(d.Id(), &infoblox.Options{ReturnBasicFields: true, ReturnFields: []string {"configure_for_dns"}})
+	opts := &infoblox.Options{
+		ReturnFields: []string{"name", "ipv4addrs", "ipv6addrs", "configure_for_dns", "comment", "ttl", "view"},
+	}
+	record, err := client.GetRecordHost(d.Id(), opts)
 	if err != nil {
 		return handleReadError(d, "Host", err)
 	}
@@ -253,7 +256,10 @@ func resourceInfobloxHostRecordRead(d *schema.ResourceData, meta interface{}) er
 func resourceInfobloxHostRecordUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*infoblox.Client)
 
-	_, err := client.GetRecordHost(d.Id(), nil)
+	opts := &infoblox.Options{
+		ReturnFields: []string{"name", "ipv4addrs", "ipv6addrs", "configure_for_dns", "comment", "ttl", "view"},
+	}
+	_, err := client.GetRecordHost(d.Id(), opts)
 	if err != nil {
 		return fmt.Errorf("error finding infoblox Host record: %s", err.Error())
 	}
@@ -263,9 +269,6 @@ func resourceInfobloxHostRecordUpdate(d *schema.ResourceData, meta interface{}) 
 
 	log.Printf("[DEBUG] Updating Infoblox Host record with configuration: %#v", hostObject)
 
-	opts := &infoblox.Options{
-		ReturnFields: []string{"name", "ipv4addr", "ipv6addr", "configure_for_dns", "comment", "ttl", "view"},
-	}
 	recordID, err := client.RecordHostObject(d.Id()).Update(record, opts, hostObject)
 	if err != nil {
 		return fmt.Errorf("error updating Infoblox Host record: %s", err.Error())

--- a/infoblox/resource_infoblox_record_mx.go
+++ b/infoblox/resource_infoblox_record_mx.go
@@ -81,7 +81,10 @@ func resourceInfobloxMXRecordCreate(d *schema.ResourceData, meta interface{}) er
 func resourceInfobloxMXRecordRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*infoblox.Client)
 
-	record, err := client.GetRecordMx(d.Id(), nil)
+	opts := &infoblox.Options{
+		ReturnFields: []string{"exchanger", "name", "pref", "comment", "ttl", "view"},
+	}
+	record, err := client.GetRecordMx(d.Id(), opts)
 	if err != nil {
 		return handleReadError(d, "MX", err)
 	}
@@ -106,7 +109,10 @@ func resourceInfobloxMXRecordRead(d *schema.ResourceData, meta interface{}) erro
 func resourceInfobloxMXRecordUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*infoblox.Client)
 
-	_, err := client.GetRecordMx(d.Id(), nil)
+	opts := &infoblox.Options{
+		ReturnFields: []string{"exchanger", "name", "pref", "comment", "ttl", "view"},
+	}
+	_, err := client.GetRecordMx(d.Id(), opts)
 	if err != nil {
 		return fmt.Errorf("error finding infoblox MX record: %s", err.Error())
 	}
@@ -119,9 +125,6 @@ func resourceInfobloxMXRecordUpdate(d *schema.ResourceData, meta interface{}) er
 
 	log.Printf("[DEBUG] Updating Infoblox MX record with configuration: %#v", record)
 
-	opts := &infoblox.Options{
-		ReturnFields: []string{"exchanger", "name", "pref", "comment", "ttl", "view"},
-	}
 	recordID, err := client.RecordMxObject(d.Id()).Update(record, opts, nil)
 	if err != nil {
 		return fmt.Errorf("error updating Infoblox MX record: %s", err.Error())

--- a/infoblox/resource_infoblox_record_ptr.go
+++ b/infoblox/resource_infoblox_record_ptr.go
@@ -89,7 +89,8 @@ func resourceInfobloxPTRRecordCreate(d *schema.ResourceData, meta interface{}) e
 func resourceInfobloxPTRRecordRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*infoblox.Client)
 
-	record, err := client.GetRecordPtr(d.Id(), nil)
+	opts := ptrOpts(d)
+	record, err := client.GetRecordPtr(d.Id(), opts)
 	if err != nil {
 		return handleReadError(d, "PTR", err)
 	}
@@ -122,7 +123,8 @@ func resourceInfobloxPTRRecordUpdate(d *schema.ResourceData, meta interface{}) e
 	client := meta.(*infoblox.Client)
 	record := url.Values{}
 
-	_, err := client.GetRecordPtr(d.Id(), nil)
+	opts := ptrOpts(d)
+	_, err := client.GetRecordPtr(d.Id(), opts)
 	if err != nil {
 		return fmt.Errorf("error finding infoblox PTR record: %s", err.Error())
 	}
@@ -141,7 +143,6 @@ func resourceInfobloxPTRRecordUpdate(d *schema.ResourceData, meta interface{}) e
 
 	log.Printf("[DEBUG] Updating Infoblox PTR record with configuration: %#v", record)
 
-	opts := ptrOpts(d)
 	recordID, err := client.RecordPtrObject(d.Id()).Update(record, opts, nil)
 	if err != nil {
 		return fmt.Errorf("error updating Infoblox PTR record: %s", err.Error())

--- a/infoblox/resource_infoblox_record_srv.go
+++ b/infoblox/resource_infoblox_record_srv.go
@@ -93,7 +93,10 @@ func resourceInfobloxSRVRecordCreate(d *schema.ResourceData, meta interface{}) e
 func resourceInfobloxSRVRecordRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*infoblox.Client)
 
-	record, err := client.GetRecordSrv(d.Id(), nil)
+	opts := &infoblox.Options{
+		ReturnFields: []string{"name", "port", "priority", "target", "weight", "comment", "ttl", "view"},
+	}
+	record, err := client.GetRecordSrv(d.Id(), opts)
 	if err != nil {
 		return handleReadError(d, "SRV", err)
 	}
@@ -120,7 +123,10 @@ func resourceInfobloxSRVRecordRead(d *schema.ResourceData, meta interface{}) err
 func resourceInfobloxSRVRecordUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*infoblox.Client)
 
-	_, err := client.GetRecordSrv(d.Id(), nil)
+	opts := &infoblox.Options{
+		ReturnFields: []string{"name", "port", "priority", "target", "weight", "comment", "ttl", "view"},
+	}
+	_, err := client.GetRecordSrv(d.Id(), opts)
 	if err != nil {
 		return fmt.Errorf("error finding infoblox SRV record: %s", err.Error())
 	}
@@ -141,9 +147,6 @@ func resourceInfobloxSRVRecordUpdate(d *schema.ResourceData, meta interface{}) e
 
 	log.Printf("[DEBUG] Updating Infoblox SRV record with configuration: %#v", record)
 
-	opts := &infoblox.Options{
-		ReturnFields: []string{"name", "port", "priority", "target", "weight", "comment", "ttl", "view"},
-	}
 	recordID, err := client.RecordSrvObject(d.Id()).Update(record, opts, nil)
 	if err != nil {
 		return fmt.Errorf("error updating Infoblox SRV record: %s", err.Error())

--- a/infoblox/resource_infoblox_record_txt.go
+++ b/infoblox/resource_infoblox_record_txt.go
@@ -73,7 +73,10 @@ func resourceInfobloxTXTRecordCreate(d *schema.ResourceData, meta interface{}) e
 func resourceInfobloxTXTRecordRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*infoblox.Client)
 
-	record, err := client.GetRecordTxt(d.Id(), nil)
+	opts := &infoblox.Options{
+		ReturnFields: []string{"name", "text", "comment", "ttl", "view"},
+	}
+	record, err := client.GetRecordTxt(d.Id(), opts)
 	if err != nil {
 		return handleReadError(d, "TXT", err)
 	}
@@ -97,7 +100,10 @@ func resourceInfobloxTXTRecordRead(d *schema.ResourceData, meta interface{}) err
 func resourceInfobloxTXTRecordUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*infoblox.Client)
 
-	_, err := client.GetRecordTxt(d.Id(), nil)
+	opts := &infoblox.Options{
+		ReturnFields: []string{"name", "text", "comment", "ttl", "view"},
+	}
+	_, err := client.GetRecordTxt(d.Id(), opts)
 	if err != nil {
 		return fmt.Errorf("error finding infoblox TXT record: %s", err.Error())
 	}
@@ -109,9 +115,6 @@ func resourceInfobloxTXTRecordUpdate(d *schema.ResourceData, meta interface{}) e
 
 	log.Printf("[DEBUG] Updating Infoblox TXT record with configuration: %#v", record)
 
-	opts := &infoblox.Options{
-		ReturnFields: []string{"name", "text", "comment", "ttl", "view"},
-	}
 	recordID, err := client.RecordTxtObject(d.Id()).Update(record, opts, nil)
 	if err != nil {
 		return fmt.Errorf("error updating Infoblox TXT record: %s", err.Error())


### PR DESCRIPTION
If we don't request the same fields on every API call, then the terraform state becomes inconsistent after various operations. This should make the API calls somewhat more consistent